### PR TITLE
Fixed CMake to include qtxdg header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(LXQT REQUIRED)
 include(${LXQT_USE_FILE})
 
+find_package(QTXDG REQUIRED)
+include(${QTXDG_USE_FILE})
+
 add_subdirectory(lxqt-session)
 add_subdirectory(lxqt-config-session)
 


### PR DESCRIPTION
Current master does not compile due to missing include directives for qtxdg. This is fixed by this commit.
