### PR TITLE
- Unify naming for a unique lxqt. No more suffixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(Qt5X11Extras REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(Qt5Xdg REQUIRED QUIET)
 
-find_package(lxqt-qt5 REQUIRED QUIET)
+find_package(lxqt REQUIRED QUIET)
 include(${LXQT_USE_FILE})
 
 include(LXQtTranslate)


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro helio@kde.org
