### PR TITLE
use devnode instead of devpath, so FreeBSD

### DIFF
--- a/lxqt-session/src/UdevNotifier.cpp
+++ b/lxqt-session/src/UdevNotifier.cpp
@@ -81,7 +81,7 @@ void UdevNotifier::eventReady(int /*socket*/)
     while (nullptr != (dev = udev_monitor_receive_device(d->monitor)))
     {
         QString const action = udev_device_get_action(dev);
-        QString const device = udev_device_get_devpath(dev);
+        QString const device = udev_device_get_devnode(dev);
 
         if (QStringLiteral("add") == action)
             emit deviceAdded(std::move(device));


### PR DESCRIPTION
The FreeBSD package `libudev-devd` implements all udev functions used here except `udev_device_get_devpath`, making the program not compilable on FreeBSD. This might be worked around by using a different function like `udev_device_get_devnode`, however the result will be different.