### PR TITLE
startlxqt: Ensure all paths are added to $XDG_CONFIG_DIRS.

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -26,9 +26,11 @@ export XDG_DATA_DIRS
 if [ -z "$XDG_CONFIG_DIRS" ]; then
     export XDG_CONFIG_DIRS="@PREDEF_XDG_CONFIG_DIRS@"
 else
-    if ! contains "$XDG_CONFIG_DIRS" '@LXQT_ETC_XDG_DIR@'; then
-        XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS:@LXQT_ETC_XDG_DIR@"
-    fi
+    for directory in "/etc" "@LXQT_ETC_XDG_DIR@" "/usr/share"; do
+        if ! contains "$XDG_CONFIG_DIRS" "$directory"; then
+            XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS:$directory"
+        fi
+    done
 fi
 
 if [ -z "$XDG_CACHE_HOME" ]; then


### PR DESCRIPTION
This is a follow-up fix to #114.

So, the move works fine on installs which have already copied files to `.config`, but we are seeing reports from people who just want a pure LXQt session with no Lubuntu settings that they are asked to select a window manager, and after that, they have a black desktop (hidden panel, no background).

This isn't a Lubuntu-specific problem, but an SDDM one. SDDM automatically assembles the `$XDG_CONFIG_DIRS` variable from `$DESKTOP_SESSION` and then adds `/etc/xdg`, so the base variable looks like this:

```
/etc/xdg/xdg-lxqt:/etc/xdg
```

That's a problem if you move settings out of `/etc/xdg`.

Since this comes from _upstream_ SDDM, we should at least do some verification that the essential paths are indeed included in `$XDG_CONFIG_DIRS`, so that regardless of the display manager, `/usr/share` and `/etc` are _always_ a part of that environment variable.

I tested this on my Lubuntu Cosmic system, and it presents no issues.

_This code is contributed on behalf of the Lubuntu Team._