### PR TITLE
Delete lxqt-config-session_zh_CN.GB2312.desktop

### DIFF
--- a/lxqt-config-session/translations/lxqt-config-session_zh_CN.GB2312.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_zh_CN.GB2312.desktop
@@ -1,1 +1,0 @@
-# Translations


### PR DESCRIPTION
Because its untranslated and these files seems to be the only ones using zh_CN.GB2312:
lxqt-config-session_zh_CN.GB2312.ts
lxqt-session_zh_CN.GB2312.ts
lxqt-config-session_zh_CN.GB2312.desktop