### PR TITLE
lockscreenmanager: Fix renewal of inhibitor lock

### DIFF
--- a/lxqt-config-session/basicsettings.cpp
+++ b/lxqt-config-session/basicsettings.cpp
@@ -35,6 +35,7 @@
 static const QLatin1String windowManagerKey("window_manager");
 static const QLatin1String leaveConfirmationKey("leave_confirmation");
 static const QLatin1String lockBeforePowerActionsKey("lock_screen_before_power_actions");
+static const QLatin1String powerActionsAfterLockDelayKey("power_actions_after_lock_delay");
 static const QLatin1String openboxValue("openbox");
 
 BasicSettings::BasicSettings(LXQt::Settings *settings, QWidget *parent) :
@@ -74,6 +75,7 @@ void BasicSettings::restoreSettings()
 
     ui->leaveConfirmationCheckBox->setChecked(m_settings->value(leaveConfirmationKey, false).toBool());
     ui->lockBeforePowerActionsCheckBox->setChecked(m_settings->value(lockBeforePowerActionsKey, true).toBool());
+    ui->powerAfterLockDelaySpinBox->setValue(m_settings->value(powerActionsAfterLockDelayKey, 0).toInt());
 }
 
 void BasicSettings::save()
@@ -87,6 +89,7 @@ void BasicSettings::save()
     const QString windowManager = ui->wmComboBox->currentText();
     const bool leaveConfirmation = ui->leaveConfirmationCheckBox->isChecked();
     const bool lockBeforePowerActions = ui->lockBeforePowerActionsCheckBox->isChecked();
+    const int powerAfterLockDelay = ui->powerAfterLockDelaySpinBox->value();
 
     QMap<QString, AutostartItem> previousItems(AutostartItem::createItemMap());
     QMutableMapIterator<QString, AutostartItem> i(previousItems);
@@ -113,6 +116,12 @@ void BasicSettings::save()
     if (lockBeforePowerActions != m_settings->value(lockBeforePowerActionsKey, true).toBool())
     {
         m_settings->setValue(lockBeforePowerActionsKey, lockBeforePowerActions);
+        doRestart = true;
+    }
+
+    if (powerAfterLockDelay != m_settings->value(powerActionsAfterLockDelayKey, 0).toInt())
+    {
+        m_settings->setValue(powerActionsAfterLockDelayKey, powerAfterLockDelay);
         doRestart = true;
     }
 

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -110,18 +110,47 @@
      <property name="title">
       <string>Leave Session</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="leaveConfirmationCheckBox">
         <property name="text">
          <string>Ask for confirmation to leave session</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="lockBeforePowerActionsCheckBox">
         <property name="text">
          <string>Lock screen before suspending/hibernating</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="powerDelayLabel">
+        <property name="text">
+         <string>Suspend/hibernate after lock delay:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="powerAfterLockDelaySpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="maximum">
+         <number>4500</number>
+        </property>
+        <property name="singleStep">
+         <number>250</number>
         </property>
        </widget>
       </item>
@@ -131,5 +160,18 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>lockBeforePowerActionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>powerAfterLockDelaySpinBox</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>lockBeforePowerActionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>powerDelayLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+ </connections>
 </ui>

--- a/lxqt-session/src/lockscreenmanager.h
+++ b/lxqt-session/src/lockscreenmanager.h
@@ -31,8 +31,10 @@
 #include <QObject>
 #include <QEventLoop>
 #include <QDBusInterface>
-#include <QDBusUnixFileDescriptor>
+#include <QScopedPointer>
 #include <LXQt/ScreenSaver>
+
+class QDBusUnixFileDescriptor;
 
 class LockScreenProvider : public QObject
 {
@@ -64,7 +66,7 @@ public:
 
 private:
     QDBusInterface mInterface;
-    QDBusUnixFileDescriptor mFileDescriptor;
+    QScopedPointer<QDBusUnixFileDescriptor> mFileDescriptor;
 };
 
 class ConsoleKit2Provider : public LockScreenProvider
@@ -82,7 +84,7 @@ public:
 private:
     QDBusInterface mInterface;
     bool mMethodInhibitPresent;
-    QDBusUnixFileDescriptor mFileDescriptor;
+    QScopedPointer<QDBusUnixFileDescriptor> mFileDescriptor;
 };
 
 class LockScreenManager : public QObject
@@ -94,6 +96,9 @@ public:
     virtual ~LockScreenManager();
 
     bool startup(bool lockBeforeSleep);
+
+private:
+    void inhibit();
 
 private:
     LockScreenProvider *mProvider;

--- a/lxqt-session/src/lockscreenmanager.h
+++ b/lxqt-session/src/lockscreenmanager.h
@@ -29,7 +29,6 @@
 #define LOCKSCREENMANAGER_H
 
 #include <QObject>
-#include <QEventLoop>
 #include <QDBusInterface>
 #include <QScopedPointer>
 #include <LXQt/ScreenSaver>
@@ -95,7 +94,7 @@ public:
     explicit LockScreenManager(QObject *parent = nullptr);
     virtual ~LockScreenManager();
 
-    bool startup(bool lockBeforeSleep);
+    bool startup(bool lockBeforeSleep, int powerAfterLockDelay/*!< ms*/);
 
 private:
     void inhibit();
@@ -105,7 +104,7 @@ private:
 
     // screensaver
     LXQt::ScreenSaver mScreenSaver;
-    QEventLoop mLoop;
+    bool mLockedBeforeSleep;
 };
 
 #endif

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -99,8 +99,8 @@ bool SessionApplication::startup()
             });
 #endif
 
-    bool lockBeforeSleep = settings.value(QLatin1String("lock_screen_before_power_actions"), true).toBool();
-    if (lockScreenManager->startup(lockBeforeSleep))
+    if (lockScreenManager->startup(settings.value(QLatin1String("lock_screen_before_power_actions"), true).toBool()
+                , settings.value(QLatin1String("power_actions_after_lock_delay"), 0).toInt()))
         qCDebug(SESSION) << "LockScreenManager started successfully";
     else
         qCWarning(SESSION) << "LockScreenManager couldn't start";


### PR DESCRIPTION
After some debuging...the inhibitor lock is not renewed after resume
from suspend and that's because QDBusUnixFileDescriptor::isValid() was
still true...

Do not assume that QDBusUnixFileDescriptor::setFileDescriptor(-1)
invalidates the object.

ref. lxqt/lxqt#1515