### PR TITLE
Don't default on Openbox

### DIFF
--- a/config/session.conf
+++ b/config/session.conf
@@ -1,5 +1,4 @@
 [General]
-window_manager=openbox
 leave_confirmation=true
 
 [Environment]

--- a/lxqt-session/src/wmselectdialog.ui
+++ b/lxqt-session/src/wmselectdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>352</width>
-    <height>276</height>
+    <width>600</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
refs lxqt/lxqt/issues/1583

It will wreck the WM logic if openbox is not installed, the dialog will appear,
even if not needed.