### PR TITLE
WIP: LXQtModule: Set subprocess output to null.

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -466,6 +466,8 @@ LXQtModule::LXQtModule(const XdgDesktopFile& file, QObject* parent) :
     fileName(QFileInfo(file.fileName()).fileName()),
     mIsTerminating(false)
 {
+    QProcess::setStandardOutputFile(QProcess::nullDevice());
+    QProcess::setStandardErrorFile(QProcess::nullDevice());
     connect(this, SIGNAL(stateChanged(QProcess::ProcessState)), SLOT(updateState(QProcess::ProcessState)));
 }
 


### PR DESCRIPTION
Otherwise QProcess will keep allocating memory to store process output we never read, as in https://github.com/lxqt/lxqt/issues/442

Test plan:

1. Have a command that writes a lot to its standard output. (see below)
2. Monitor lxqt-session memory usage, using qps or `ps -C lxqt-session -F` (watch RSS)
3. Run the command through lxqt-panel or lxqt-runner.
4. Confirm lxqt-session memory usage did not increase.

Why is this a patch to lxqt-session if the output is coming from a program launched from panel or runner? Because they forward the output of their children. (I think. Something about using `QProcess::startDetached` instead of capturing the child in its own QProcess.) You could instead test by adding an LXQtModule that generates a bunch of output directly, but that sounds like more work. 

To write a bunch to standard output:

The first time I did this I just ran `yes`. That worked _too well_; everything crashed. Better to have something that writes a large but finite amount. e.g. [hundredmeg.txt](https://github.com/lxqt/lxqt-session/files/3050311/hundredmeg.txt)

