### PR TITLE
startlxqt: remove redundant SAL_USE_VCLPLUGIN var

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -46,11 +46,6 @@ mkdir -p "$XDG_DESKTOP_DIR"
 # Clean up after GDM (GDM sets the number of desktops to one)
 xprop -root -remove _NET_NUMBER_OF_DESKTOPS -remove _NET_DESKTOP_NAMES -remove _NET_CURRENT_DESKTOP 2> /dev/null
 
-# Enable Qt integration for OpenOffice.org, if available.
-if [ -z "$SAL_USE_VCLPLUGIN" ]; then
-    export SAL_USE_VCLPLUGIN=kde4
-fi
-
 # Launch DBus if needed
 if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
     if [ -z "$XDG_RUNTIME_DIR" ] || ! [ -S "$XDG_RUNTIME_DIR/bus" ] || ! [ -O "$XDG_RUNTIME_DIR/bus" ]; then


### PR DESCRIPTION
In the latest LibreOffice, the kde4 VCL plugin is gone, so `export SAL_USE_VCLPLUGIN=kde4` has no effects.

And OpenOffice is dead.

Closes https://github.com/lxqt/lxqt/issues/1673