### PR TITLE
Added SAL_USE_VCLPLUGIN=qt5

### DIFF
--- a/config/session.conf
+++ b/config/session.conf
@@ -4,6 +4,7 @@ leave_confirmation=true
 [Environment]
 GTK_CSD=0
 GTK_OVERLAY_SCROLLING=0
+SAL_USE_VCLPLUGIN=qt5
 
 [Mouse]
 cursor_size=18


### PR DESCRIPTION
The Qt5 plugin is really usable now and we should promote it. It's in the
discretion of the distribution maintainers to make sure that it is installed.