### PR TITLE
lxqt-leave: correct dialog location

### DIFF
--- a/lxqt-leave/leavedialog.cpp
+++ b/lxqt-leave/leavedialog.cpp
@@ -127,12 +127,3 @@ LeaveDialog::~LeaveDialog()
 {
     delete ui;
 }
-
-void LeaveDialog::resizeEvent(QResizeEvent* /*event*/)
-{
-    const QScreen *primaryScreen = QGuiApplication::primaryScreen();
-    const QRect screen = primaryScreen ? primaryScreen->geometry() : QRect();
-    move((screen.width()  - this->width()) / 2,
-         (screen.height() - this->height()) / 2);
-
-}

--- a/lxqt-leave/leavedialog.h
+++ b/lxqt-leave/leavedialog.h
@@ -47,9 +47,6 @@ public:
     explicit LeaveDialog(QWidget *parent = nullptr);
     ~LeaveDialog() override;
 
-protected:
-    void resizeEvent(QResizeEvent* event) override;
-
 private:
     Ui::LeaveDialog *ui;
     // LXQt::Power is used to know if the actions are doable, while

--- a/lxqt-leave/main.cpp
+++ b/lxqt-leave/main.cpp
@@ -112,11 +112,6 @@ int main(int argc, char *argv[])
     LeaveDialog dialog;
     a.setActivationWindow(&dialog);
     dialog.setFixedSize(dialog.sizeHint());
-    const QScreen *screen = QGuiApplication::screenAt(QCursor::pos());
-    const QRect rect = screen ? screen->geometry() : QRect();
-    dialog.setGeometry(QStyle::alignedRect(Qt::LeftToRight,
-                Qt::AlignCenter,
-                dialog.sizeHint(),
-                rect));
+
     return dialog.exec();
 }


### PR DESCRIPTION
Dialog show up in weird place on multi monitor environment.
Current code (wrongly) adjust dialog's geometry in various location. But
in fact these code aren't necessary because QDialog automatically move
dialog to center of the screen. It also do the right thing on multiple
monitor environment (center dialog on monitor that the mouse cursor
currently is in).