### PR TITLE
Port to new Qt5 signal/slot syntax

### DIFF
--- a/lxqt-config-session/autostartedit.cpp
+++ b/lxqt-config-session/autostartedit.cpp
@@ -38,7 +38,7 @@ AutoStartEdit::AutoStartEdit(const QString& name, const QString& command, bool n
     ui->nameEdit->setText(name);
     ui->commandEdit->setText(command);
     ui->trayCheckBox->setChecked(needTray);
-    connect(ui->browseButton, SIGNAL(clicked()), SLOT(browse()));
+    connect(ui->browseButton, &QPushButton::clicked, this, &AutoStartEdit::browse);
 }
 
 QString AutoStartEdit::name()

--- a/lxqt-config-session/autostartpage.cpp
+++ b/lxqt-config-session/autostartpage.cpp
@@ -38,9 +38,9 @@ AutoStartPage::AutoStartPage(QWidget* parent) :
 {
     ui->setupUi(this);
 
-    connect(ui->addButton, SIGNAL(clicked()), SLOT(addButton_clicked()));
-    connect(ui->editButton, SIGNAL(clicked()), SLOT(editButton_clicked()));
-    connect(ui->deleteButton, SIGNAL(clicked()), SLOT(deleteButton_clicked()));
+    connect(ui->addButton,    &QPushButton::clicked, this, &AutoStartPage::addButton_clicked);
+    connect(ui->editButton,   &QPushButton::clicked, this, &AutoStartPage::editButton_clicked);
+    connect(ui->deleteButton, &QPushButton::clicked, this, &AutoStartPage::deleteButton_clicked);
 
     restoreSettings();
 }
@@ -59,9 +59,8 @@ void AutoStartPage::restoreSettings()
     ui->autoStartView->setExpanded(mXdgAutoStartModel->index(0, 0), true);
     ui->autoStartView->setExpanded(mXdgAutoStartModel->index(1, 0), true);
     updateButtons();
-    connect(mXdgAutoStartModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)), SLOT(updateButtons()));
-    connect(ui->autoStartView->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)),
-            SLOT(selectionChanged(QModelIndex)));
+    connect(mXdgAutoStartModel, &AutoStartItemModel::dataChanged, this, &AutoStartPage::updateButtons);
+    connect(ui->autoStartView->selectionModel(), &QItemSelectionModel::currentChanged, this, &AutoStartPage::selectionChanged);
 }
 
 void AutoStartPage::save()

--- a/lxqt-config-session/basicsettings.cpp
+++ b/lxqt-config-session/basicsettings.cpp
@@ -45,9 +45,9 @@ BasicSettings::BasicSettings(LXQt::Settings *settings, QWidget *parent) :
     ui(new Ui::BasicSettings)
 {
     ui->setupUi(this);
-    connect(ui->findWmButton, SIGNAL(clicked()), this, SLOT(findWmButton_clicked()));
-    connect(ui->startButton, SIGNAL(clicked()), this, SLOT(startButton_clicked()));
-    connect(ui->stopButton, SIGNAL(clicked()), this, SLOT(stopButton_clicked()));
+    connect(ui->findWmButton, &QPushButton::clicked, this, &BasicSettings::findWmButton_clicked);
+    connect(ui->startButton,  &QPushButton::clicked, this, &BasicSettings::startButton_clicked);
+    connect(ui->stopButton,   &QPushButton::clicked, this, &BasicSettings::stopButton_clicked);
     restoreSettings();
 
     ui->moduleView->setModel(m_moduleModel);

--- a/lxqt-config-session/environmentpage.cpp
+++ b/lxqt-config-session/environmentpage.cpp
@@ -37,10 +37,9 @@ EnvironmentPage::EnvironmentPage(LXQt::Settings *settings, QWidget *parent) :
 {
     ui->setupUi(this);
 
-    connect(ui->addButton, SIGNAL(clicked()), SLOT(addButton_clicked()));
-    connect(ui->deleteButton, SIGNAL(clicked()), SLOT(deleteButton_clicked()));
-    connect(ui->treeWidget, SIGNAL(itemChanged(QTreeWidgetItem*,int)),
-            SLOT(itemChanged(QTreeWidgetItem*,int)));
+    connect(ui->addButton,    &QPushButton::clicked,     this, &EnvironmentPage::addButton_clicked);
+    connect(ui->deleteButton, &QPushButton::clicked,     this, &EnvironmentPage::deleteButton_clicked);
+    connect(ui->treeWidget,   &QTreeWidget::itemChanged, this, &EnvironmentPage::itemChanged);
 
     /* restoreSettings() is called from SessionConfigWindow
        after connections with DefaultApps have been set up */

--- a/lxqt-config-session/sessionconfigwindow.cpp
+++ b/lxqt-config-session/sessionconfigwindow.cpp
@@ -45,31 +45,31 @@ SessionConfigWindow::SessionConfigWindow() :
 {
     BasicSettings* basicSettings = new BasicSettings(mSettings, this);
     addPage(basicSettings, tr("Basic Settings"), QSL("preferences-desktop-display-color"));
-    connect(basicSettings, SIGNAL(needRestart()), SLOT(setRestart()));
-    connect(this, SIGNAL(reset()), basicSettings, SLOT(restoreSettings()));
-    connect(this, SIGNAL(save()), basicSettings, SLOT(save()));
+    connect(basicSettings, &BasicSettings::needRestart, this, &SessionConfigWindow::setRestart);
+    connect(this, &SessionConfigWindow::reset, basicSettings, &BasicSettings::restoreSettings);
+    connect(this, &SessionConfigWindow::save,  basicSettings, &BasicSettings::save);
 
     UserLocationsPage* userLocations = new UserLocationsPage(this);
     addPage(userLocations, tr("User Directories"), QStringLiteral("folder"));
-    connect(userLocations, SIGNAL(needRestart()), SLOT(setRestart()));
-    connect(this, SIGNAL(reset()), userLocations, SLOT(restoreSettings()));
-    connect(this, SIGNAL(save()), userLocations, SLOT(save()));
+    connect(userLocations, &UserLocationsPage::needRestart, this, &SessionConfigWindow::setRestart);
+    connect(this, &SessionConfigWindow::reset, userLocations, &UserLocationsPage::restoreSettings);
+    connect(this, &SessionConfigWindow::save,  userLocations, &UserLocationsPage::save);
 
     AutoStartPage* autoStart = new AutoStartPage(this);
     addPage(autoStart, tr("Autostart"), QSL("preferences-desktop-launch-feedback"));
-    connect(autoStart, SIGNAL(needRestart()), SLOT(setRestart()));
-    connect(this, SIGNAL(reset()), autoStart, SLOT(restoreSettings()));
-    connect(this, SIGNAL(save()), autoStart, SLOT(save()));
+    connect(autoStart, &AutoStartPage::needRestart, this, &SessionConfigWindow::setRestart);
+    connect(this, &SessionConfigWindow::reset, autoStart, &AutoStartPage::restoreSettings);
+    connect(this, &SessionConfigWindow::save, autoStart, &AutoStartPage::save);
 
     EnvironmentPage* environmentPage = new EnvironmentPage(mSettings, this);
     addPage(environmentPage, tr("Environment (Advanced)"), QSL("preferences-system-session-services"));
-    connect(environmentPage, SIGNAL(needRestart()), SLOT(setRestart()));
-    connect(this, SIGNAL(reset()), environmentPage, SLOT(restoreSettings()));
-    connect(this, SIGNAL(save()), environmentPage, SLOT(save()));
+    connect(environmentPage, &EnvironmentPage::needRestart, this, &SessionConfigWindow::setRestart);
+    connect(this, &SessionConfigWindow::reset, environmentPage, &EnvironmentPage::restoreSettings);
+    connect(this, &SessionConfigWindow::save,  environmentPage, &EnvironmentPage::save);
 
     // sync Default Apps and Environment
     environmentPage->restoreSettings();
-    connect(this, SIGNAL(reset()), SLOT(clearRestart()));
+    connect(this, &SessionConfigWindow::reset, this, &SessionConfigWindow::clearRestart);
     m_restart = false;
 
     adjustSize();

--- a/lxqt-config-session/userlocationspage.cpp
+++ b/lxqt-config-session/userlocationspage.cpp
@@ -130,15 +130,14 @@ UserLocationsPage::UserLocationsPage(QWidget *parent)
 
         QToolButton *button = new QToolButton(this);
         button->setIcon(XdgIcon::fromTheme(QStringLiteral("folder")));
-        connect(button, SIGNAL(clicked()), d->signalMapper, SLOT(map()));
+        connect(button, &QToolButton::clicked, d->signalMapper, QOverload<>::of(&QSignalMapper::map));
         d->signalMapper->setMapping(button, i);
 
         gridLayout->addWidget(label, row, 0);
         gridLayout->addWidget(edit, row, 1);
         gridLayout->addWidget(button, row, 2);
     }
-    connect(d->signalMapper, SIGNAL(mapped(int)),
-            this, SLOT(clicked(int)));
+    connect(d->signalMapper, QOverload<int>::of(&QSignalMapper::mapped), this, &UserLocationsPage::clicked);
 
     QSpacerItem *verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum,
                                                   QSizePolicy::Expanding);

--- a/lxqt-session/src/lockscreenmanager.cpp
+++ b/lxqt-session/src/lockscreenmanager.cpp
@@ -85,16 +85,14 @@ bool LockScreenManager::startup(bool lockBeforeSleep, int powerAfterLockDelay)
                 }
             });
 
-    connect(mProvider, &LockScreenProvider::lockRequested, [this] {
+    connect(mProvider, &LockScreenProvider::lockRequested, this, [this] {
         qCDebug(SESSION) << "LockScreenManager: lock requested";
         mScreenSaver.lockScreen();
     });
 
     if (lockBeforeSleep)
     {
-        connect(mProvider,
-                &LockScreenProvider::aboutToSleep,
-                [this] (bool beforeSleep)
+        connect(mProvider, &LockScreenProvider::aboutToSleep, this, [this] (bool beforeSleep)
         {
             if (beforeSleep)
             {
@@ -133,8 +131,8 @@ LogindProvider::LogindProvider() :
 {
     if (mInterface.isValid())
     {
-        connect(&mInterface, SIGNAL(PrepareForSleep(bool)),
-                this, SIGNAL(aboutToSleep(bool)));
+        // SIGNAL/SLOT macros are needed here
+        connect(&mInterface, SIGNAL(PrepareForSleep(bool)), this, SIGNAL(aboutToSleep(bool)));
 
         QString sessionId = QDBusInterface(
                 QStringLiteral("org.freedesktop.login1"),
@@ -217,8 +215,8 @@ ConsoleKit2Provider::ConsoleKit2Provider() :
 
         if (mMethodInhibitPresent)
         {
-            connect(&mInterface, SIGNAL(PrepareForSleep(bool)),
-                    this, SIGNAL(aboutToSleep(bool)));
+            // SIGNAL/SLOT macros are needed here
+            connect(&mInterface, SIGNAL(PrepareForSleep(bool)), this, SIGNAL(aboutToSleep(bool)));
 
             QDBusReply<QDBusObjectPath> sessionObjectPath = mInterface
                 .call(QSL("GetCurrentSession"));

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -85,16 +85,16 @@ bool SessionApplication::startup()
     QTimer * dev_timer = new QTimer{this}; //will be released upon our destruction
     dev_timer->setSingleShot(true);
     dev_timer->setInterval(500); //give some time to xorg... we need to reset keyboard afterwards
-    connect(dev_timer, &QTimer::timeout, [this]
+    connect(dev_timer, &QTimer::timeout, this, [this]
             {
                 //XXX: is this a race? (because settings can be currently changed by lxqt-config-input)
                 //     but with such a little probablity we can live...
                 LXQt::Settings settings(configName);
                 loadKeyboardSettings(settings);
             });
-    connect(dev_notifier, &UdevNotifier::deviceAdded, [this, dev_timer] (QString device)
+    connect(dev_notifier, &UdevNotifier::deviceAdded, this, [this, dev_timer] (QString device)
             {
-                qCWarning(SESSION) << QStringLiteral("Session '%1', new input device '%2', keyboard setting will be (optionaly) reloaded...").arg(configName).arg(device);
+                qCWarning(SESSION) << QStringLiteral("Session '%1', new input device '%2', keyboard setting will be (optionaly) reloaded...").arg(configName,device);
                 dev_timer->start();
             });
     // Detect display connection:
@@ -103,9 +103,9 @@ bool SessionApplication::startup()
     // # echo detect > status
     // at /sys/devices/pciXXX/drm/cardX/cardX-XXX
     UdevNotifier *dev_notifier_drm_subsystem = new UdevNotifier(QStringLiteral("drm"), this); //will be released upon our destruction
-    connect(dev_notifier_drm_subsystem, &UdevNotifier::deviceChanged, [this] (QString device)
+    connect(dev_notifier_drm_subsystem, &UdevNotifier::deviceChanged, this, [this] (QString device)
             {
-                qCWarning(SESSION) << QStringLiteral("Session '%1': display device '%2'").arg(configName).arg(device);
+                qCWarning(SESSION) << QStringLiteral("Session '%1': display device '%2'").arg(configName,device);
                 QProcess::startDetached(QStringLiteral("lxqt-config-monitor"), QStringList(QStringLiteral("-l")));
             });
 #endif

--- a/lxqt-session/src/sessiondbusadaptor.h
+++ b/lxqt-session/src/sessiondbusadaptor.h
@@ -50,7 +50,7 @@ public:
           m_manager(manager),
           m_power(false/*don't use ourself, just all other power providers*/)
     {
-        connect(m_manager, SIGNAL(moduleStateChanged(QString,bool)), SIGNAL(moduleStateChanged(QString,bool)));
+        connect(m_manager, &LXQtModuleManager::moduleStateChanged, this, &SessionDBusAdaptor::moduleStateChanged);
     }
 
 signals:

--- a/lxqt-session/src/wmselectdialog.cpp
+++ b/lxqt-session/src/wmselectdialog.cpp
@@ -51,9 +51,9 @@ WmSelectDialog::WmSelectDialog(const WindowManagerList &availableWindowManagers,
     qApp->setStyle(QSL("plastique"));
     ui->setupUi(this);
     setModal(true);
-    connect(ui->wmList, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(accept()));
-    connect(ui->wmList, SIGNAL(clicked(QModelIndex)), this, SLOT(selectFileDialog(QModelIndex)));
-    connect(ui->wmList, SIGNAL(activated(QModelIndex)), this, SLOT(changeBtnStatus(QModelIndex)));
+    connect(ui->wmList, &QTreeWidget::doubleClicked, this, &WmSelectDialog::accept);
+    connect(ui->wmList, &QTreeWidget::clicked,       this, &WmSelectDialog::selectFileDialog);
+    connect(ui->wmList, &QTreeWidget::activated,     this, &WmSelectDialog::changeBtnStatus);
 
     for (const WindowManager &wm : availableWindowManagers)
     {


### PR DESCRIPTION
I couldn't do it for QDBusInterface signals. Added a FIXME
to easily find them.

clazy fixes: connect-3args-lambda