### PR TITLE
Fix core when lxqt-session is started under Wayland server.

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -83,7 +83,8 @@ void LXQtModuleManager::startup(LXQt::Settings& s)
     startConfUpdate();
 
     // Start window manager
-    startWm(&s);
+    if(QX11Info::isPlatformX11())
+        startWm(&s);
 
     startAutostartApps();
 

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -37,8 +37,6 @@
 // XKB, this should be disabled in Wayland?
 #include <X11/XKBlib.h>
 
-#include <LXQt/lxqtplatform.h>
-
 SessionApplication::SessionApplication(int& argc, char** argv) :
     LXQt::Application(argc, argv),
     lockScreenManager(new LockScreenManager(this))
@@ -83,8 +81,7 @@ bool SessionApplication::startup()
     loadEnvironmentSettings(settings);
     // loadFontSettings(settings);
 
-    LXQt::Platform::PLATFORM platform = LXQt::Platform::getPlatform();
-    if(platform == LXQt::Platform::X11) {
+    if(QGuiApplication::platformName() == QStringLiteral("xcb")) {
         // X11 session is started
         loadKeyboardSettings(settings);
         loadMouseSettings(settings);
@@ -100,7 +97,8 @@ bool SessionApplication::startup()
                 //XXX: is this a race? (because settings can be currently changed by lxqt-config-input)
                 //     but with such a little probablity we can live...
                 LXQt::Settings settings(configName);
-                loadKeyboardSettings(settings);
+                if(QGuiApplication::platformName() == QStringLiteral("xcb"))
+                    loadKeyboardSettings(settings);
             });
     connect(dev_notifier, &UdevNotifier::deviceAdded, this, [this, dev_timer] (QString device)
             {

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -37,19 +37,13 @@
 // XKB, this should be disabled in Wayland?
 #include <X11/XKBlib.h>
 
+#include <LXQt/lxqtplatform.h>
+
 SessionApplication::SessionApplication(int& argc, char** argv) :
     LXQt::Application(argc, argv),
     lockScreenManager(new LockScreenManager(this))
 {
     listenToUnixSignals({SIGINT, SIGTERM, SIGQUIT, SIGHUP});
-
-    {
-        // Checks wayland session
-        QString platform = QGuiApplication::platformName();
-	qDebug() << "Platform" << platform;
-	if(platform == QStringLiteral("wayland"))
-		qDebug() << "\tWayland session";
-    }
 
     modman = new LXQtModuleManager;
     connect(this, &LXQt::Application::unixSignal, modman, [this] { modman->logout(true); });
@@ -88,7 +82,10 @@ bool SessionApplication::startup()
 
     loadEnvironmentSettings(settings);
     // loadFontSettings(settings);
-    if(QX11Info::isPlatformX11()) {
+
+    LXQt::Platform::PLATFORM platform = LXQt::Platform::getPlatform();
+    if(platform == LXQt::Platform::X11) {
+        // X11 session is started
         loadKeyboardSettings(settings);
         loadMouseSettings(settings);
     }


### PR DESCRIPTION
Some parts of lxqt-session must be run under X11 platform. A simple check has been added to avoid those parts under Wayland server.