### PR TITLE
ifdef/remove deprecated methods

### DIFF
--- a/lxqt-config-session/autostartmodel.cpp
+++ b/lxqt-config-session/autostartmodel.cpp
@@ -150,8 +150,8 @@ bool AutoStartItemModel::removeRow(int row, const QModelIndex& parent)
 
     if (!mItemMap[item].removeLocal())
     {
-        QModelIndex index = this->index(row, 0, parent);
-        emit dataChanged(index, index);
+        QModelIndex indx = index(row, 0, parent);
+        emit dataChanged(indx, indx);
         return false;
     }
 

--- a/lxqt-config-session/autostartmodel.cpp
+++ b/lxqt-config-session/autostartmodel.cpp
@@ -150,7 +150,7 @@ bool AutoStartItemModel::removeRow(int row, const QModelIndex& parent)
 
     if (!mItemMap[item].removeLocal())
     {
-        QModelIndex index = parent.child(row, 0);
+        QModelIndex index = this->index(row, 0, parent);
         emit dataChanged(index, index);
         return false;
     }

--- a/lxqt-config-session/userlocationspage.cpp
+++ b/lxqt-config-session/userlocationspage.cpp
@@ -137,7 +137,11 @@ UserLocationsPage::UserLocationsPage(QWidget *parent)
         gridLayout->addWidget(edit, row, 1);
         gridLayout->addWidget(button, row, 2);
     }
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
+    connect(d->signalMapper, &QSignalMapper::mappedInt, this, &UserLocationsPage::clicked);
+#else
     connect(d->signalMapper, QOverload<int>::of(&QSignalMapper::mapped), this, &UserLocationsPage::clicked);
+#endif
 
     QSpacerItem *verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum,
                                                   QSizePolicy::Expanding);


### PR DESCRIPTION
The QSignalMapper::mapped is a trivial ifdef. The QModelIndex change needs deep review.