### PR TITLE
Removed `QTXDG_START_DETACH_TRULY`

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -64,6 +64,5 @@ export XDG_MENU_PREFIX="lxqt-"
 
 export XDG_CURRENT_DESKTOP="LXQt"
 
-export QTXDG_START_DETACH_TRULY=0
 # Start the LXQt session
 exec lxqt-session


### PR DESCRIPTION
The work behind `QTXDG_START_DETACH_TRULY` was a good attempt at terminating apps with the session end (and avoiding rare crashes in apps like qlipper) but, IMHO, this approach isn't the solution and can damage UX in serious ways (hence its removeal, instead of setting it to `1`):

 1. Logically, exiting a component like Panel is the necessary but not sufficient condition for the session end.
 2. For example, the user may stop Panel from LXQt Session Settings. If he does so, not only LXQt Session Settings itself will suddenly disappear but also there might be no obvious way of restoring Panel.
 3. Lots of work may be lost by just stopping Panel inside a session because apps like FeatherPad, Kate,… are terminated without prompt.
 4. Also, non-editting apps, like Firefox or any browser, may suddenly disappear inside a session and baffle the user.
 5. As far as I know, no other DE does it in that way.

Closes https://github.com/lxqt/libqtxdg/issues/245
Reverses https://github.com/lxqt/lxqt-session/commit/b4ae46c2e5fdb19f45bb4177f8d0c37ef7b237d1