### PR TITLE
session: Become subreaper & end children upon finish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
 find_package(X11 REQUIRED)
 message(STATUS "Building with Qt${Qt5Core_VERSION}")
+find_package(PkgConfig REQUIRED)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    pkg_search_module(PROCPS REQUIRED libprocps)
+endif()
 
 # Please don't move, must be after lxqt
 find_package(XdgUserDirs REQUIRED)

--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -9,6 +9,11 @@ endif()
 include_directories(
     ${X11_INCLUDE_DIR}
 )
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    include_directories(
+        ${PROCPS_INCLUDE_DIRS}
+    )
+endif()
 
 set(lxqt-session_HDRS "")
 
@@ -24,6 +29,7 @@ set(lxqt-session_SRCS
     src/numlock.cpp
     src/numlock.h
     src/log.cpp
+    src/procreaper.cpp
 )
 if (WITH_LIBUDEV)
     list(APPEND lxqt-session_SRCS src/UdevNotifier.cpp)
@@ -61,6 +67,11 @@ target_link_libraries(lxqt-session
     ${X11_LIBRARIES}
     KF5::WindowSystem
 )
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(lxqt-session
+        ${PROCPS_LIBRARIES}
+    )
+endif()
 
 if (WITH_LIBUDEV)
     target_link_libraries(lxqt-session ${UDEV_LIBS})

--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -70,6 +70,7 @@ LXQtModuleManager::LXQtModuleManager(QObject* parent)
     connect(LXQt::Settings::globalSettings(), &LXQt::GlobalSettings::lxqtThemeChanged, this, &LXQtModuleManager::themeChanged);
 
     qApp->installNativeEventFilter(this);
+    mProcReaper.start();
 }
 
 void LXQtModuleManager::setWindowManager(const QString & windowManager)
@@ -364,6 +365,9 @@ void LXQtModuleManager::logout(bool doExit)
             p->kill();
         }
     }
+
+    // terminate all possible children except WM
+    mProcReaper.stop({mWmProcess->processId()});
 
     mWmProcess->terminate();
     if (mWmProcess->state() != QProcess::NotRunning && !mWmProcess->waitForFinished(2000))

--- a/lxqt-session/src/lxqtmodman.h
+++ b/lxqt-session/src/lxqtmodman.h
@@ -36,6 +36,7 @@
 #include <XdgDesktopFile>
 #include <QEventLoop>
 #include <time.h>
+#include "procreaper.h"
 
 class LXQtModule;
 namespace LXQt {
@@ -141,6 +142,8 @@ private:
     bool mWmStarted;
     bool mTrayStarted;
     QEventLoop* mWaitLoop;
+
+    ProcReaper mProcReaper;
 
 private slots:
 

--- a/lxqt-session/src/procreaper.cpp
+++ b/lxqt-session/src/procreaper.cpp
@@ -1,0 +1,115 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2021~ LXQt team
+ * Authors:
+ *  Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "procreaper.h"
+#include "log.h"
+#if defined(Q_OS_LINUX)
+#include <sys/prctl.h>
+#include <proc/readproc.h>
+#endif
+#include <cstring>
+#include <cerrno>
+#include <sys/wait.h>
+
+ProcReaper::ProcReaper()
+    : mShouldRun{true}
+{
+#if defined(Q_OS_LINUX)
+    int result = prctl(PR_SET_CHILD_SUBREAPER, 1);
+    if (result != 0)
+        qCWarning(SESSION) << "Unable to to set PR_SET_CHILD_SUBREAPER, " << result << " - " << strerror(errno);
+#endif
+}
+
+ProcReaper::~ProcReaper()
+{
+    stop({});
+}
+
+void ProcReaper::run()
+{
+    pid_t pid = 0;
+    while (true)
+    {
+        if (pid <= 0)
+        {
+            QMutexLocker guard{&mMutex};
+            mWait.wait(&mMutex, std::chrono::seconds(1));
+        }
+
+        int status;
+        pid = ::waitpid(-1, &status, WNOHANG);
+        if (pid < 0)
+        {
+            if (ECHILD != errno)
+                qCDebug(SESSION) << "waitpid failed " << strerror(errno);
+        } else if (pid > 0)
+        {
+            if (WIFEXITED(status))
+                qCDebug(SESSION) << "Child process " << pid << " exited with status " << WEXITSTATUS(status);
+            else if (WIFSIGNALED(status))
+                qCDebug(SESSION) << "Child process " << pid << " terminated on signal " << WTERMSIG(status);
+            else
+                qCDebug(SESSION) << "Child process " << pid << " ended";
+        }
+        {
+            QMutexLocker guard{&mMutex};
+            if (!mShouldRun && pid <= 0)
+                break;
+        }
+    }
+}
+
+void ProcReaper::stop(const std::set<int64_t> & excludedPids)
+{
+    {
+        QMutexLocker guard{&mMutex};
+        if (!mShouldRun)
+            return;
+    }
+    // send term to all children
+#if defined(Q_OS_LINUX)
+    const pid_t my_pid = ::getpid();
+    PROCTAB * proc_dir = ::openproc(PROC_FILLSTAT);
+    while (proc_t * proc = ::readproc(proc_dir, nullptr))
+    {
+        if (proc->ppid == my_pid && excludedPids.count(proc->ppid) == 0)
+        {
+            qCDebug(SESSION) << "Seding TERM to child " << proc->tgid;
+            ::kill(proc->tgid, SIGTERM);
+        }
+        ::freeproc(proc);
+    }
+    ::closeproc(proc_dir);
+#endif
+    mWait.wakeAll();
+    {
+        QMutexLocker guard{&mMutex};
+        mShouldRun = false;
+    }
+    QThread::wait(std::chrono::seconds(5));
+}

--- a/lxqt-session/src/procreaper.h
+++ b/lxqt-session/src/procreaper.h
@@ -1,0 +1,45 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt.org
+ *
+ * Copyright: 2021~ LXQt team
+ * Authors:
+ *  Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include <QThread>
+#include <QMutex>
+#include <QWaitCondition>
+#include <set>
+
+class ProcReaper : public QThread
+{
+public:
+    ProcReaper();
+    ~ProcReaper();
+public:
+    virtual void run() override;
+    void stop(const std::set<int64_t> & excludedPids);
+private:
+    bool mShouldRun;
+    QMutex mMutex;
+    QWaitCondition mWait;
+};


### PR DESCRIPTION
This is another approach to "correctly stop all children upon session exit":
1. upon start become a subreaper (a process which become a parent of its descendants if its immediate parent ends)
2. upon session finish send TERM to all children processes and give them a bit time to finish gracefully

This logic is currently implemented only for Linux (proper if/ifdefs used), but based on goole-fu, there are possibilities to implement this for BSD also
https://stackoverflow.com/questions/62365978/get-a-list-of-child-processes-from-parent-process-in-c-and-c-cross-platform
https://unix.stackexchange.com/questions/149319/new-parent-process-when-the-parent-process-dies

@jsm222 Could you have a look for the BSD changes?