### PR TITLE
Restart failed modules with exit codes other than 0

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -273,7 +273,7 @@ void LXQtModuleManager::startConfUpdate()
     startProcess(desktop);
 }
 
-void LXQtModuleManager::restartModules(int /*exitCode*/, QProcess::ExitStatus exitStatus)
+void LXQtModuleManager::restartModules(int exitCode, QProcess::ExitStatus exitStatus)
 {
     LXQtModule* proc = qobject_cast<LXQtModule*>(sender());
     if (nullptr == proc) {
@@ -288,7 +288,9 @@ void LXQtModuleManager::restartModules(int /*exitCode*/, QProcess::ExitStatus ex
         {
             case QProcess::NormalExit:
                 qCDebug(SESSION) << "Process" << procName << "(" << proc << ") exited correctly.";
-                break;
+                if (exitCode == 0)
+                    break;
+                // Falls through.
             case QProcess::CrashExit:
             {
                 qCDebug(SESSION) << "Process" << procName << "(" << proc << ") has to be restarted";

--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -200,7 +200,7 @@ void LXQtModuleManager::startWm(LXQt::Settings *settings)
     }
 
     mWmProcess->start(mWindowManager, QStringList());
-    
+
     // other autostart apps will be handled after the WM becomes available
 
     // Wait until the WM loads
@@ -287,7 +287,7 @@ void LXQtModuleManager::restartModules(int exitCode, QProcess::ExitStatus exitSt
         switch (exitStatus)
         {
             case QProcess::NormalExit:
-                qCDebug(SESSION) << "Process" << procName << "(" << proc << ") exited correctly.";
+                qCDebug(SESSION) << "Process" << procName << "(" << proc << ") exited with code" << exitCode;
                 if (exitCode == 0)
                     break;
                 // Falls through.


### PR DESCRIPTION
Previously, the exit code was ignored when restarting modules.

Recently, after a suspicious libx11 commit, `lxqt-globalkeysd` may randomly fail at login without crash (see https://github.com/lxqt/lxqt-globalkeys/issues/247). This patch works around the problem but, in general, I found no reason to ignore the exit code — unless I'm missing something…

NOTE: I didn't add a new text for the warning message because, as far as the user is concerned, a sudden exit isn't different from a crash. Also, allowing for 5 extra restarts for the exit code 1 *independently of probable crashes* seemed too much.