### PR TITLE
Added an option for screen scaling

### DIFF
--- a/lxqt-config-session/basicsettings.h
+++ b/lxqt-config-session/basicsettings.h
@@ -47,6 +47,7 @@ public:
 
 signals:
     void needRestart();
+    void scaleFactorChanged();
 
 public slots:
     void restoreSettings();

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -106,6 +106,44 @@
     </widget>
    </item>
    <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Screen Scale</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::ExpandingFieldsGrow</enum>
+      </property>
+      <property name="horizontalSpacing">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Scale factor:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="scaleSpinBox">
+        <property name="minimum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>4.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.500000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Leave Session</string>

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -108,7 +108,7 @@
    <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
-      <string>Screen Scale</string>
+      <string>Global Screen Scaling</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">

--- a/lxqt-config-session/environmentpage.cpp
+++ b/lxqt-config-session/environmentpage.cpp
@@ -80,7 +80,7 @@ void EnvironmentPage::save()
 
     m_settings->beginGroup(QL1S("Environment"));
 
-    /* We erase the Enviroment group and them write the Ui settings. To know if
+    /* We erase the Enviroment group and then write the Ui settings. To know if
        they changed or not we need to save them to memory.
      */
     const auto keys = m_settings->childKeys();
@@ -152,3 +152,12 @@ void EnvironmentPage::updateItem(const QString& var, const QString& val)
             delete item;
     }
 }
+
+void EnvironmentPage::updateScaleFactor()
+{
+    m_settings->beginGroup(QL1S("Environment"));
+    updateItem(QL1S("QT_SCALE_FACTOR"), m_settings->value(QL1S("QT_SCALE_FACTOR"), 1).toString());
+    updateItem(QL1S("GDK_SCALE"), m_settings->value(QL1S("GDK_SCALE"), 1).toString());
+    m_settings->endGroup();
+}
+

--- a/lxqt-config-session/environmentpage.h
+++ b/lxqt-config-session/environmentpage.h
@@ -50,11 +50,13 @@ signals:
 public slots:
     void restoreSettings();
     void save();
-    void updateItem(const QString &var, const QString &val);
+    void updateScaleFactor();
 
 private:
     LXQt::Settings *m_settings;
     Ui::EnvironmentPage *ui;
+
+    void updateItem(const QString &var, const QString &val);
 
 private slots:
     void addButton_clicked();

--- a/lxqt-config-session/sessionconfigwindow.cpp
+++ b/lxqt-config-session/sessionconfigwindow.cpp
@@ -67,6 +67,10 @@ SessionConfigWindow::SessionConfigWindow() :
     connect(this, &SessionConfigWindow::reset, environmentPage, &EnvironmentPage::restoreSettings);
     connect(this, &SessionConfigWindow::save,  environmentPage, &EnvironmentPage::save);
 
+    // Update EnvironmentPage on changing scale factor; otherwise, scale factor will not change
+    // because "EnvironmentPage::save()" overwrites EVs.
+    connect(basicSettings, &BasicSettings::scaleFactorChanged, environmentPage, &EnvironmentPage::updateScaleFactor);
+
     // sync Default Apps and Environment
     environmentPage->restoreSettings();
     connect(this, &SessionConfigWindow::reset, this, &SessionConfigWindow::clearRestart);


### PR DESCRIPTION
Let's have a minimal option for screen scaling and talk about probable better options later. It just sets `QT_SCALE_FACTOR` and `GDK_SCALE` to a value between 1.0 and 4.0 (greater factors don't seem useful and might cause trouble if chosen by mistake).

Closes https://github.com/lxqt/lxqt/issues/2173 and closes https://github.com/lxqt/lxqt-config/issues/402