### PR TITLE
Set Clearlooks default theme

### DIFF
--- a/config/lxqt.conf
+++ b/config/lxqt.conf
@@ -1,5 +1,5 @@
 [General]
-theme=frost
+theme=Clearlooks
 icon_theme=breeze
 single_click_activate=false
 tool_button_style=ToolButtonTextBesideIcon


### PR DESCRIPTION
The last piece for improving default vanilla appearance. It will look like that:

![Light+waves-logo](https://user-images.githubusercontent.com/10681413/160471480-d5ff7630-e53c-418b-a62f-68d4b6a430f3.png)
