### PR TITLE
Fix desktop file

### DIFF
--- a/lxqt-config-session/lxqt-config-session.desktop.in
+++ b/lxqt-config-session/lxqt-config-session.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Exec=lxqt-config-session
 Icon=preferences-system-session-services
-Categories=Settings;DesktopSettings;Qt;LXQt;
+Categories=Settings;DesktopSettings;Qt;
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
desktop-file-validate: "Categories" in group "Desktop Entry" contains an unregistered value "LXQt"