### PR TITLE
Updates the DBus activation environment

### DIFF
--- a/lxqt-session/src/sessionapplication.h
+++ b/lxqt-session/src/sessionapplication.h
@@ -48,6 +48,7 @@ private:
 
     void mergeXrdb(const char* content, int len);
     void setLeftHandedMouse(bool mouse_left_handed);
+    bool updateDBusEnvironment();
 private:
     LXQtModuleManager* modman;
     LockScreenManager *lockScreenManager;


### PR DESCRIPTION
We use dbus-update-activation-environment to update the list of environment variables used by dbus-daemon --session. Some applications might not work properly if the DBus variables are not set.

Assuming that the executable name is always `dbus-update-activation-environment`.

Closes https://github.com/lxqt/lxqt-runner/issues/265.