### PR TITLE
Disable dbus activation of xdg-desktop-portal until the dbus environment is updated

### DIFF
--- a/lxqt-session/src/main.cpp
+++ b/lxqt-session/src/main.cpp
@@ -51,6 +51,7 @@ session-eggwm.conf
 */
 int main(int argc, char **argv)
 {
+    qputenv("QT_NO_XDG_DESKTOP_PORTAL", QByteArrayLiteral("1"));
     SessionApplication app(argc, argv);
 
     QCommandLineParser parser;

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -83,6 +83,7 @@ bool SessionApplication::startup()
         QMessageBox::warning(nullptr, tr("DBus Environment"),
                 tr("The DBus Activation Environment wasn't updated. Some apps might not work properly"));
     }
+    qunsetenv("QT_NO_XDG_DESKTOP_PORTAL");
 
     // loadFontSettings(settings);
 
@@ -348,6 +349,9 @@ bool SessionApplication::updateDBusEnvironment()
 {
     qCDebug(SESSION) << "Updating DBus activation environment:";
     QProcess p;
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.remove(QStringLiteral("QT_NO_XDG_DESKTOP_PORTAL"));
+    p.setProcessEnvironment(env);
     p.setProgram(QStringLiteral("dbus-update-activation-environment"));
     p.setArguments(QStringList(QStringLiteral("--all")));
     p.start();


### PR DESCRIPTION
QT seems to automatically call xdg-desktop-portal via dbus [1], which might cause xdg-desktop-portal to be dbus activated before we sync our environment to dbus, breaking portal selection via XDG_CURRENT_DESKTOP.

Opt out [2] of their portal usage until `updateDBusEnvironment` finishes.

See also https://invent.kde.org/plasma/plasma-workspace/-/commit/670cf731a75037c646864ed0bd03a35a35130c5e

Fixes https://github.com/lxqt/xdg-desktop-portal-lxqt/issues/23

[1]: https://invent.kde.org/qt/qt/qtbase/-/commit/9d65da811207992a97c5391d1e2e1981f8bae114
[2]: https://invent.kde.org/qt/qt/qtbase/-/commit/b4b7f6f5a5636c7ded0c8285fce8d41d0ab30b29