### PR TITLE
Add UI for custom screenlock command 

### DIFF
--- a/lxqt-config-session/basicsettings.h
+++ b/lxqt-config-session/basicsettings.h
@@ -62,6 +62,7 @@ private slots:
     void findWmButton_clicked();
     void startButton_clicked();
     void stopButton_clicked();
+    void findLockCommandButton_clicked();
 };
 
 #endif // BASICSETTINGS_H

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -192,6 +192,42 @@
         </property>
        </widget>
       </item>
+       <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Screen Lock Command</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="useCustomLockCommandCheckBox">
+        <property name="text">
+         <string>Use custom screen lock command</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QComboBox" name="lockCommandComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="findLockCommandButton">
+        <property name="text">
+         <string>Search...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Rebased version of https://github.com/lxqt/lxqt-session/pull/322 

Does not compile yet:
```
cpp:91:68: error: ‘useCustomLockCommand’ was not declared in this scope; did you mean ‘useCustomLockCommandKey’?
   91 |     ui->useCustomLockCommandCheckBox->setChecked(m_settings->value(useCustomLockCommand, false).toBool());
      |                                                                    ^~~~~~~~~~~~~~~~~~~~
```
Needs https://github.com/lxqt/liblxqt/pull/346
Fixes https://github.com/lxqt/lxqt/issues/1664