### PR TITLE
Reenable locksettings under wayland

### DIFF
--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -124,7 +124,7 @@ bool SessionApplication::startup()
 #endif
     }
 
-    if (lockScreenManager->startup(isX11 ? settings.value(QLatin1String("lock_screen_before_power_actions"), true).toBool() : false
+    if (lockScreenManager->startup(settings.value(QLatin1String("lock_screen_before_power_actions"), true).toBool()
                 , settings.value(QLatin1String("power_actions_after_lock_delay"), 0).toInt()))
         qCDebug(SESSION) << "LockScreenManager started successfully";
     else


### PR DESCRIPTION
Reverts partially https://github.com/lxqt/lxqt-session/commit/0048ae69b38fb9db6b339787336d16c944869551

No crash of lxqt-session is happening now as `isScreenSaverLocked` isn't called anymore.
https://github.com/lxqt/liblxqt/commit/255f3474f6ad765dd0a6bdc305f13116ba6cb4db

Just the error message about` xdg-screensaver lock` is displayed if checked.

Needed by https://github.com/lxqt/liblxqt/pull/346