### PR TITLE
GUI for custom screenlocker on x11

### DIFF
--- a/lxqt-config-session/basicsettings.cpp
+++ b/lxqt-config-session/basicsettings.cpp
@@ -37,8 +37,10 @@ static const QLatin1String leaveConfirmationKey("leave_confirmation");
 static const QLatin1String lockBeforePowerActionsKey("lock_screen_before_power_actions");
 static const QLatin1String powerActionsAfterLockDelayKey("power_actions_after_lock_delay");
 static const QLatin1String QtScaleKey("QT_SCALE_FACTOR");
+static const QLatin1String x11LockCommandKey("lock_command");
 static const QLatin1String GdkScaleKey("GDK_SCALE");
 static const QLatin1String openboxValue("openbox");
+static const QLatin1String emptyValue("");
 
 BasicSettings::BasicSettings(LXQt::Settings *settings, QWidget *parent) :
     QWidget(parent),
@@ -50,6 +52,7 @@ BasicSettings::BasicSettings(LXQt::Settings *settings, QWidget *parent) :
     connect(ui->findWmButton, &QPushButton::clicked, this, &BasicSettings::findWmButton_clicked);
     connect(ui->startButton,  &QPushButton::clicked, this, &BasicSettings::startButton_clicked);
     connect(ui->stopButton,   &QPushButton::clicked, this, &BasicSettings::stopButton_clicked);
+    connect(ui->findX11LockCommandButton, &QPushButton::clicked, this, &BasicSettings::findX11LockCommandButton_clicked);
     restoreSettings();
 
     ui->moduleView->setModel(m_moduleModel);
@@ -71,6 +74,11 @@ void BasicSettings::restoreSettings()
         knownWMs << wm.command;
     }
 
+    QStringList knownX11Locker;
+    knownX11Locker << QStringLiteral("i3lock") << QStringLiteral("kscreenlocker") << QStringLiteral("slock")  << QStringLiteral("xss-lock") << QStringLiteral("xsecurelock")<< QStringLiteral("xlock");//we could also add "xdg-screensaver lock"" and make it the default value, removing the "custom"
+
+    QString currentPlatform = QGuiApplication::platformName();
+
     QString wm = m_settings->value(windowManagerKey, openboxValue).toString();
     SessionConfigWindow::handleCfgComboBox(ui->wmComboBox, knownWMs, wm);
     m_moduleModel->reset();
@@ -82,6 +90,10 @@ void BasicSettings::restoreSettings()
     m_settings->beginGroup(QL1S("Environment"));
     ui->scaleSpinBox->setValue(m_settings->value(QtScaleKey, 1.0).toDouble());
     m_settings->endGroup();
+
+    QString x11LockCommand = m_settings->value(x11LockCommandKey, emptyValue).toString();
+    SessionConfigWindow::handleCfgComboBox(ui->x11LockCommandComboBox, knownX11Locker, x11LockCommand);
+    m_moduleModel->reset();
 }
 
 void BasicSettings::save()
@@ -97,6 +109,7 @@ void BasicSettings::save()
     const bool lockBeforePowerActions = ui->lockBeforePowerActionsCheckBox->isChecked();
     const int powerAfterLockDelay = ui->powerAfterLockDelaySpinBox->value();
     const double scaleFactor = ui->scaleSpinBox->value();
+    const QString x11LockCommand = ui->x11LockCommandComboBox->currentText();
 
     QMap<QString, AutostartItem> previousItems(AutostartItem::createItemMap());
     QMutableMapIterator<QString, AutostartItem> i(previousItems);
@@ -113,7 +126,6 @@ void BasicSettings::save()
         doRestart = true;
     }
 
-
     if (leaveConfirmation != m_settings->value(leaveConfirmationKey, false).toBool())
     {
         m_settings->setValue(leaveConfirmationKey, leaveConfirmation);
@@ -129,6 +141,12 @@ void BasicSettings::save()
     if (powerAfterLockDelay != m_settings->value(powerActionsAfterLockDelayKey, 0).toInt())
     {
         m_settings->setValue(powerActionsAfterLockDelayKey, powerAfterLockDelay);
+        doRestart = true;
+    }
+
+    if (x11LockCommand != m_settings->value(x11LockCommandKey, emptyValue).toString())
+    {
+        m_settings->setValue(x11LockCommandKey, x11LockCommand);
         doRestart = true;
     }
 
@@ -184,4 +202,9 @@ void BasicSettings::startButton_clicked()
 void BasicSettings::stopButton_clicked()
 {
     m_moduleModel->toggleModule(ui->moduleView->selectionModel()->currentIndex(), false);
+}
+
+void BasicSettings::findX11LockCommandButton_clicked()
+{
+    SessionConfigWindow::updateCfgComboBox(ui->x11LockCommandComboBox, tr("Select a screenlocker"));
 }

--- a/lxqt-config-session/basicsettings.h
+++ b/lxqt-config-session/basicsettings.h
@@ -62,6 +62,7 @@ private slots:
     void findWmButton_clicked();
     void startButton_clicked();
     void stopButton_clicked();
+    void findX11LockCommandButton_clicked();
 };
 
 #endif // BASICSETTINGS_H

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>322</width>
-    <height>380</height>
+    <width>446</width>
+    <height>711</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
@@ -15,7 +15,6 @@
     <widget class="QLabel" name="label">
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -27,7 +26,7 @@
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Window Manager</string>
+      <string>X11 Window Manager</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -53,19 +52,12 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>LXQt Modules</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="7" column="1">
-       <widget class="QPushButton" name="startButton">
-        <property name="text">
-         <string>Start</string>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="2">
        <widget class="QPushButton" name="stopButton">
         <property name="text">
@@ -73,18 +65,12 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="7" column="1">
+       <widget class="QPushButton" name="startButton">
+        <property name="text">
+         <string>Start</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+       </widget>
       </item>
       <item row="0" column="0" colspan="3">
        <widget class="QTreeView" name="moduleView">
@@ -102,17 +88,30 @@
         </attribute>
        </widget>
       </item>
+      <item row="7" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Global Screen Scaling</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
       </property>
       <property name="horizontalSpacing">
        <number>6</number>
@@ -143,16 +142,23 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Leave Session</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="leaveConfirmationCheckBox">
+      <item row="3" column="0">
+       <widget class="QLabel" name="X11LockCommandLabel">
         <property name="text">
-         <string>Ask for confirmation to leave session</string>
+         <string>Custom screenlock command:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QPushButton" name="findX11LockCommandButton">
+        <property name="text">
+         <string>Search...</string>
         </property>
        </widget>
       </item>
@@ -160,6 +166,29 @@
        <widget class="QCheckBox" name="lockBeforePowerActionsCheckBox">
         <property name="text">
          <string>Lock screen before suspending/hibernating</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="leaveConfirmationCheckBox">
+        <property name="text">
+         <string>Ask for confirmation to leave session</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QComboBox" name="x11LockCommandComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>If empty "xdg-screensaver lock" is used</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -202,14 +231,18 @@
   <connection>
    <sender>lockBeforePowerActionsCheckBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>powerAfterLockDelaySpinBox</receiver>
-   <slot>setEnabled(bool)</slot>
-  </connection>
-  <connection>
-   <sender>lockBeforePowerActionsCheckBox</sender>
-   <signal>toggled(bool)</signal>
    <receiver>powerDelayLabel</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>711</height>
+    <width>322</width>
+    <height>380</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
@@ -15,6 +15,7 @@
     <widget class="QLabel" name="label">
      <property name="font">
       <font>
+       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -26,7 +27,7 @@
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>X11 Window Manager</string>
+      <string>Window Manager</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -52,12 +53,19 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>LXQt Modules</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="7" column="1">
+       <widget class="QPushButton" name="startButton">
+        <property name="text">
+         <string>Start</string>
+        </property>
+       </widget>
+      </item>
       <item row="7" column="2">
        <widget class="QPushButton" name="stopButton">
         <property name="text">
@@ -65,12 +73,18 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
-       <widget class="QPushButton" name="startButton">
-        <property name="text">
-         <string>Start</string>
+      <item row="7" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
-       </widget>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item row="0" column="0" colspan="3">
        <widget class="QTreeView" name="moduleView">
@@ -88,30 +102,17 @@
         </attribute>
        </widget>
       </item>
-      <item row="7" column="0">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Global Screen Scaling</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
+       <enum>QFormLayout::ExpandingFieldsGrow</enum>
       </property>
       <property name="horizontalSpacing">
        <number>6</number>
@@ -142,33 +143,12 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="4" column="0">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Leave Session</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="3" column="0">
-       <widget class="QLabel" name="X11LockCommandLabel">
-        <property name="text">
-         <string>Custom screenlock command:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QPushButton" name="findX11LockCommandButton">
-        <property name="text">
-         <string>Search...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="lockBeforePowerActionsCheckBox">
-        <property name="text">
-         <string>Lock screen before suspending/hibernating</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="leaveConfirmationCheckBox">
         <property name="text">
@@ -176,19 +156,10 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QComboBox" name="x11LockCommandComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>If empty "xdg-screensaver lock" is used</string>
-        </property>
-        <property name="editable">
-         <bool>true</bool>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="lockBeforePowerActionsCheckBox">
+        <property name="text">
+         <string>Lock screen before suspending/hibernating</string>
         </property>
        </widget>
       </item>
@@ -221,6 +192,41 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QGroupBox" name="customLockBox">
+        <property name="title">
+         <string>Use custom screen lock command</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="1" column="1">
+          <widget class="QPushButton" name="findX11LockCommandButton">
+           <property name="text">
+            <string>Search...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QComboBox" name="x11LockCommandComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -231,18 +237,14 @@
   <connection>
    <sender>lockBeforePowerActionsCheckBox</sender>
    <signal>toggled(bool)</signal>
+   <receiver>powerAfterLockDelaySpinBox</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>lockBeforePowerActionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
    <receiver>powerDelayLabel</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>


### PR DESCRIPTION
Needs https://github.com/lxqt/liblxqt/pull/346

Settings go to `session.conf` which is more natural as also the delay is here and it is about session locking. The PR above checks for backward compatibility first `lxqt.conf`.

```
[General]
__userfile__=true
leave_confirmation=false
lock_command=slock
lock_screen_before_power_actions=true
power_actions_after_lock_delay=2250
window_manager=kwin_x11
```
We could also remove the "custom" and use `xdg-screensaver lock` as empty/default value.

In the list I added all screenlockers from [here](https://wiki.archlinux.org/title/Session_lock), except AUR.

Window Manager → X11 Window Manager