### PR TITLE
Added wayland session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(SHELLQT_MINIMUM_VERSION "6.0.0")
 find_package(Qt6DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
-find_package(KF6WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
+find_package(KF6WindowSystem ${KF6_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
 find_package(qtxdg-tools ${QTXDG_MINIMUM_VERSION} REQUIRED)
 find_package(X11 REQUIRED)
@@ -75,8 +75,10 @@ endif()
 set(PREDEF_XDG_DATA_DIRS "${PREDEF_XDG_DATA_DIRS}:/usr/local/share:/usr/share")
 set(PREDEF_XDG_CONFIG_DIRS "/etc:${LXQT_ETC_XDG_DIR}:/usr/share")
 configure_file(startlxqt.in startlxqt @ONLY)
+configure_file(startlxqtwayland.in startlxqtwayland @ONLY)
 install(PROGRAMS
     "${CMAKE_CURRENT_BINARY_DIR}/startlxqt"
+    "${CMAKE_CURRENT_BINARY_DIR}/startlxqtwayland"
     DESTINATION "${CMAKE_INSTALL_BINDIR}"
     COMPONENT Runtime
 )
@@ -90,6 +92,6 @@ install(FILES
 add_subdirectory(config)
 add_subdirectory(autostart)
 
-# xsession *.desktop file for display managers
+# *.desktop files for display managers
 add_subdirectory(xsession)
-
+add_subdirectory(waylandsession)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" O
 option(WITH_LIBUDEV "Build with libudev support" ON)
 
 # Minimum Versions
-set(KF6_MINIMUM_VERSION "6.6.0")
+set(KF6_MINIMUM_VERSION "6.0.0")
 set(LXQT_MINIMUM_VERSION "2.0.0")
 set(QTXDG_MINIMUM_VERSION "4.0.0")
 set(QT_MINIMUM_VERSION "6.6.0")

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -6,3 +6,15 @@ install(FILES
     DESTINATION "${CMAKE_INSTALL_DATADIR}/lxqt"
     COMPONENT Runtime
 )
+install(FILES
+    lxqt-hyprland.conf
+    lxqt-wayfire.ini
+    lxqt-sway.config
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/lxqt/wayland"
+    COMPONENT Runtime
+)
+install(DIRECTORY
+    labwc
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/lxqt/wayland"
+    COMPONENT Runtime
+)

--- a/config/labwc/README
+++ b/config/labwc/README
@@ -1,0 +1,9 @@
+Config layout for ~/.config/labwc/
+- autostart
+- environment
+- menu.xml
+- rc.xml
+- themerc-override
+
+See `man labwc-config and `man labwc-theme` for further details.
+

--- a/config/labwc/autostart
+++ b/config/labwc/autostart
@@ -1,0 +1,32 @@
+# Example autostart file for a labwc LXQt session
+# Applications started here won't be closed by `lxqt-leave --logout` and settings can be lost
+# Preferred place for starting wayland-only applications
+
+# Set background color or image (below the desktop)):
+swaybg -i /usr/share/lxqt/wallpapers/origami-dark-labwc.png  >/dev/null 2>&1 &
+
+# Faster startup for GTK apps:
+dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY > /dev/null 2>&1 &
+
+# Configure output directives such as mode, position, scale and transform.
+# Use wlr-randr to get your output names
+# Example ~/.config/kanshi/config below:
+#   profile {
+#     output HDMI-A-1 position 1366,0
+#     output eDP-1 position 0,0
+#   }
+# kanshi >/dev/null 2>&1 &
+# wdisplays can be used as well on the fly
+
+#
+# Note that in the context of idle system power management, it is *NOT* a good
+# idea to turn off displays by 'disabling outputs' for example by
+# `wlr-randr --output <whatever> --off` because this re-arranges views
+# (since a837fef). Instead use a wlr-output-power-management client such as
+# https://git.sr.ht/~leon_plickat/wlopm
+#
+# Suspending can be configured in LXQt power management settings
+# Screen locking can be configured in Session Settings
+# Turn off display(s) after 5 minutes
+swayidle -w timeout 300 "wlopm --off \*" resume "wlopm --on \*" > /dev/null 2>1 &
+

--- a/config/labwc/environment
+++ b/config/labwc/environment
@@ -1,0 +1,21 @@
+# LXQt labwc environment file
+
+# This allows xdg-desktop-portal-wlr to function (e.g. for screen-recording)
+# XDG_CURRENT_DESKTOP is set to LXQt:labwc:wlroots at startup.
+# XDG_CURRENT_DESKTOP=wlroots
+
+# Disable hardware cursors. Most users wouldn't want to do this, but if you
+# are experiencing issues with disappearing cursors, this might fix it.
+# Autodetected at startup on virtualized hardware which use systemd
+#WLR_NO_HARDWARE_CURSORS=1
+
+# For Java applications such as JetBrains/Intellij Idea, set this variable
+# to avoid menus with incorrect offset and blank windows
+# See https://github.com/swaywm/sway/issues/595
+_JAVA_AWT_WM_NONREPARENTING=1
+
+# Firefox
+MOZ_ENABLE_WAYLAND=1
+
+# Cursor theme and size are imported from LXQt at login. Configure under LXQt in "Appearance → Cursor".
+# Keyboard layout and toggle options are imported only once from LXQt, edit here to change

--- a/config/labwc/menu.xml
+++ b/config/labwc/menu.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<openbox_menu>
+
+<menu id="root-menu" label="">
+  <item label="QTerminal"><action name="Execute" command="qterminal" /></item>
+  <item label="Filemanager"><action name="Execute" command="pcmanfm-qt"/></item>
+  <item label="Start LXQt Session"><action name="Execute" command="lxqt-session"/></item>
+
+  <separator />
+  <item label="LXQt Settings"><action name="Execute" command="lxqt-config" /></item>
+  <item label="Reconfigure Labwc"><action name="Reconfigure" /></item>
+  <separator />
+  <item label="Logout"><action name="Exit" /></item>
+</menu>
+
+</openbox_menu>
+

--- a/config/labwc/rc.xml
+++ b/config/labwc/rc.xml
@@ -67,6 +67,12 @@
     <keybind key="F12">
       <action name="Execute" command="toggledropdown" />
     </keybind>
+    <!-- Powerbutton-->
+    <keybind key="XF86PowerOff">
+      <action name="Execute">
+        <command>lxqt-leave</command>
+      </action>
+    </keybind>
   </keyboard>
 
   <mouse>

--- a/config/labwc/rc.xml
+++ b/config/labwc/rc.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+
+<!--
+  This is a very basic config file for labwc with LXQt with many options missing. For a complete
+  set of options with comments, see docs/rc.xml.all
+  Theme "Vent-dark" has to be copied to ~/.local/share/themes/Vent-dark"
+-->
+
+<labwc_config>
+
+  <core>
+    <gap>10</gap>
+  </core>
+
+ <theme>
+    <name>Vent</name>
+    <cornerRadius>10</cornerRadius>
+    <font place="ActiveWindow">
+      <name>sans</name>
+      <size>13</size>
+      <slant>normal</slant>
+      <weight>bold</weight>
+    </font>
+    <font place="InActiveWindow">
+      <name>sans</name>
+      <size>13</size>
+      <slant>normal</slant>
+      <weight>bold</weight>
+    </font>
+    <font place="MenuItem">
+      <name>sans</name>
+      <size>12</size>
+      <slant>normal</slant>
+      <weight>normal</weight>
+    </font>
+    <font place="OnScreenDisplay">
+      <name>sans</name>
+      <size>13</size>
+      <slant>normal</slant>
+      <weight>normal</weight>
+    </font>
+  </theme>
+
+  <keyboard>
+    <default />
+    <!-- Reload config -->
+    <keybind key="C-S-r">
+      <action name="Reconfigure"/>
+    </keybind>
+    <!-- LXQt Keybindings -->
+    <keybind key="W-Return">
+      <action name="Execute" command="qterminal" />
+    </keybind>
+    <keybind key="W-p">
+      <action name="Execute" command="pcmanfm-qt" />
+    </keybind>
+    <keybind key="W-f">
+      <action name="Execute" command="fpad" />
+    </keybind>
+    <keybind key="A-Space">
+      <action name="Execute" command="lxqt-runner" />
+    </keybind>
+    <keybind key="A-F2">
+      <action name="Execute" command="lxqt-runner" />
+    </keybind>
+    <!-- For qterminal dropdown -->
+    <keybind key="F12">
+      <action name="Execute" command="toggledropdown" />
+    </keybind>
+  </keyboard>
+
+  <mouse>
+    <default />
+    <!-- Show root menu on desktop also with right click -->
+   <context name="Root">
+      <mousebind button="Left" action="Press">
+        <action name="ShowMenu">
+          <menu>root-menu</menu>
+        </action>
+      </mousebind>
+      <mousebind button="Right" action="Press">
+        <action name="ShowMenu">
+          <menu>root-menu</menu>
+        </action>
+      </mousebind>
+      <mousebind button="Middle" action="Press">
+        <action name="ShowMenu">
+          <menu>root-menu</menu>
+        </action>
+      </mousebind>
+    </context>
+  </mouse>
+
+
+    <!--
+    The *category* element can be set to touch, non-touch, default or the name
+    of a device. You can obtain device names by running *libinput list-devices*
+    as root or member of the input group.
+    Tap is set to *yes* be default. All others are left blank in order to use
+    device defaults.
+    All values are [yes|no] except for:
+      - pointerSpeed [-1.0 to 1.0]
+      - accelProfile [flat|adaptive]
+      - tapButtonMap [lrm|lmr]
+  -->
+  <libinput>
+    <device category="default">
+      <naturalScroll>no</naturalScroll>
+      <leftHanded/>
+      <pointerSpeed>1</pointerSpeed>
+      <accelProfile>adaptive</accelProfile>
+      <tap>yes</tap>
+      <tapButtonMap/>
+      <middleEmulation/>
+      <disableWhileTyping>yes</disableWhileTyping>
+    </device>
+  </libinput>
+
+</labwc_config>

--- a/config/labwc/themerc
+++ b/config/labwc/themerc
@@ -1,0 +1,54 @@
+# This file contains all themerc options with default values
+#
+# System-wide and local themes can be overridden by creating a copy of this
+# file and renaming it to $HOME/.config/labwc/themerc-override. Be careful
+# though - if you only want to override a small number of specific options,
+# make sure all other lines are commented out or deleted.
+
+# general
+border.width: 1
+padding.height: 3
+
+# window border
+window.active.border.color: #dddad6
+window.inactive.border.color: #f6f5f4
+
+# window titlebar background
+window.active.title.bg.color: #dddad6
+window.inactive.title.bg.color: #f6f5f4
+
+# window titlebar text
+window.active.label.text.color: #000000
+window.inactive.label.text.color: #000000
+window.label.text.justify: center
+
+# window buttons
+window.active.button.unpressed.image.color: #000000
+window.inactive.button.unpressed.image.color: #000000
+
+# Note that "menu", "iconify", "max", "close" buttons colors can be defined
+# individually by inserting the type after the button node, for example:
+#
+#     window.active.button.iconify.unpressed.image.color: #333333
+
+# menu
+menu.overlap.x: 0
+menu.overlap.y: 0
+menu.width.min: 20
+menu.width.max: 200
+menu.items.bg.color: #fcfbfa
+menu.items.text.color: #000000
+menu.items.active.bg.color: #dddad6
+menu.items.active.text.color: #000000
+menu.items.padding.x: 7
+menu.items.padding.y: 4
+menu.separator.width: 1
+menu.separator.padding.width: 6
+menu.separator.padding.height: 3
+menu.separator.color: #888888
+
+# on screen display (window-cycle dialog)
+osd.bg.color: #dddda6
+osd.border.color: #000000
+osd.border.width: 1
+osd.label.text.color: #000000

--- a/config/lxqt-hyprland.conf
+++ b/config/lxqt-hyprland.conf
@@ -48,6 +48,7 @@ exec-once=lxqt-session && hyprctl dispatch exit
 
 bind = Alt, F2, exec, $menu
 bind = , F12, exec, qterminal -d
+bind = , XF86PowerOff, exec, lxqt-leave
 
 windowrule = float,^(lxqt-.*)$
 windowrule = float,^(pavucontrol-qt)$

--- a/config/lxqt-hyprland.conf
+++ b/config/lxqt-hyprland.conf
@@ -1,0 +1,267 @@
+# This is an example Hyprland config file.
+# Refer to the wiki for more information.
+# https://wiki.hyprland.org/Configuring/Configuring-Hyprland/
+
+# Please note not all available settings / options are set here.
+# For a full list, see the wiki
+
+# You can split this configuration into multiple files
+# Create your files separately and then link them to this file like this:
+# source = ~/.config/hypr/myColors.conf
+
+
+################
+### MONITORS ###
+################
+
+# See https://wiki.hyprland.org/Configuring/Monitors/
+monitor=,preferred,auto,1
+
+
+###################
+### MY PROGRAMS ###
+###################
+
+# See https://wiki.hyprland.org/Configuring/Keywords/
+
+# Set programs that you use
+$terminal = qterminal
+$fileManager = pcmanfm-qt
+$menu = lxqt-runner
+
+#################
+### LXQt      ###
+#################
+env = QT_QPA_PLATFORMTHEME,lxqt
+env = QT_PLATFORM_PLUGIN,lxqt
+env = XDG_MENU_PREFIX,lxqt-
+env = XDG_CURRENT_DESKTOP,LXQt:Hyprland:wlroots
+
+# start  and exit LXQt session:
+exec-once=lxqt-session && hyprctl dispatch exit
+
+# If not using lxqt-session uncomment components to autostart
+#exec-once=lxqt-notificationd
+#exec-once=sleep 2 && lxqt-powermanagement
+#exec-once=lxqt-policykit
+#exec-once=pcmanfm-qt --desktop
+
+bind = Alt, F2, exec, $menu
+bind = , F12, exec, qterminal -d
+
+windowrule = float,^(lxqt-.*)$
+windowrule = float,^(pavucontrol-qt)$
+windowrule = float,^(sddm-conf)$
+windowrule = float,^(kvantummanager)$
+windowrule = float,^(pcmanfm-qt)$
+windowrule = float,copyq
+
+#############################
+### ENVIRONMENT VARIABLES ###
+#############################
+
+# See https://wiki.hyprland.org/Configuring/Environment-variables/
+
+env = XCURSOR_SIZE,24
+env = HYPRCURSOR_SIZE,24
+
+
+#####################
+### LOOK AND FEEL ###
+#####################
+
+# Refer to https://wiki.hyprland.org/Configuring/Variables/
+
+# https://wiki.hyprland.org/Configuring/Variables/#general
+general {
+    gaps_in = 5
+    gaps_out = 20
+
+    border_size = 2
+
+    # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
+    col.active_border = rgba(33ccffee) rgba(00ff99ee) 45deg
+    col.inactive_border = rgba(595959aa)
+
+    # Set to true enable resizing windows by clicking and dragging on borders and gaps
+    resize_on_border = false
+
+    # Please see https://wiki.hyprland.org/Configuring/Tearing/ before you turn this on
+    allow_tearing = false
+
+    layout = dwindle
+}
+
+# https://wiki.hyprland.org/Configuring/Variables/#decoration
+decoration {
+    rounding = 10
+
+    # Change transparency of focused and unfocused windows
+    active_opacity = 1.0
+    inactive_opacity = 1.0
+
+    drop_shadow = true
+    shadow_range = 4
+    shadow_render_power = 3
+    col.shadow = rgba(1a1a1aee)
+
+    # https://wiki.hyprland.org/Configuring/Variables/#blur
+    blur {
+        enabled = true
+        size = 3
+        passes = 1
+
+        vibrancy = 0.1696
+    }
+}
+
+# https://wiki.hyprland.org/Configuring/Variables/#animations
+animations {
+    enabled = true
+
+    # Default animations, see https://wiki.hyprland.org/Configuring/Animations/ for more
+
+    bezier = myBezier, 0.05, 0.9, 0.1, 1.05
+
+    animation = windows, 1, 7, myBezier
+    animation = windowsOut, 1, 7, default, popin 80%
+    animation = border, 1, 10, default
+    animation = borderangle, 1, 8, default
+    animation = fade, 1, 7, default
+    animation = workspaces, 1, 6, default
+}
+
+# See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
+dwindle {
+    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
+    preserve_split = true # You probably want this
+}
+
+# See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
+master {
+    new_is_master = true
+}
+
+# https://wiki.hyprland.org/Configuring/Variables/#misc
+misc {
+    force_default_wallpaper = -1 # Set to 0 or 1 to disable the anime mascot wallpapers
+    disable_hyprland_logo = false # If true disables the random hyprland logo / anime girl background. :(
+}
+
+
+#############
+### INPUT ###
+#############
+
+# https://wiki.hyprland.org/Configuring/Variables/#input
+input {
+    kb_layout = us
+    kb_variant =
+    kb_model =
+    kb_options =
+    kb_rules =
+
+    follow_mouse = 1
+
+    sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
+
+    touchpad {
+        natural_scroll = false
+    }
+}
+
+# https://wiki.hyprland.org/Configuring/Variables/#gestures
+gestures {
+    workspace_swipe = false
+}
+
+# Example per-device config
+# See https://wiki.hyprland.org/Configuring/Keywords/#per-device-input-configs for more
+device {
+    name = epic-mouse-v1
+    sensitivity = -0.5
+}
+
+
+####################
+### KEYBINDINGSS ###
+####################
+
+# See https://wiki.hyprland.org/Configuring/Keywords/
+$mainMod = SUPER # Sets "Windows" key as main modifier
+
+# Ensure applications opened by shortcut are closed gently by LXQt like this for featherpad:
+bind = $mainMod, F, exec, pcmanfm-qt '/usr/share/applications/featherpad.desktop'
+
+# Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
+bind = $mainMod, Q, exec, $terminal
+bind = $mainMod, C, killactive,
+bind = $mainMod, M, exit,
+bind = $mainMod, E, exec, $fileManager
+bind = $mainMod, V, togglefloating,
+bind = $mainMod, R, exec, $menu
+bind = $mainMod, P, pseudo, # dwindle
+bind = $mainMod, J, togglesplit, # dwindle
+
+# Move focus with mainMod + arrow keys
+bind = $mainMod, left, movefocus, l
+bind = $mainMod, right, movefocus, r
+bind = $mainMod, up, movefocus, u
+bind = $mainMod, down, movefocus, d
+
+# Switch workspaces with mainMod + [0-9]
+bind = $mainMod, 1, workspace, 1
+bind = $mainMod, 2, workspace, 2
+bind = $mainMod, 3, workspace, 3
+bind = $mainMod, 4, workspace, 4
+bind = $mainMod, 5, workspace, 5
+bind = $mainMod, 6, workspace, 6
+bind = $mainMod, 7, workspace, 7
+bind = $mainMod, 8, workspace, 8
+bind = $mainMod, 9, workspace, 9
+bind = $mainMod, 0, workspace, 10
+
+# Move active window to a workspace with mainMod + SHIFT + [0-9]
+bind = $mainMod SHIFT, 1, movetoworkspace, 1
+bind = $mainMod SHIFT, 2, movetoworkspace, 2
+bind = $mainMod SHIFT, 3, movetoworkspace, 3
+bind = $mainMod SHIFT, 4, movetoworkspace, 4
+bind = $mainMod SHIFT, 5, movetoworkspace, 5
+bind = $mainMod SHIFT, 6, movetoworkspace, 6
+bind = $mainMod SHIFT, 7, movetoworkspace, 7
+bind = $mainMod SHIFT, 8, movetoworkspace, 8
+bind = $mainMod SHIFT, 9, movetoworkspace, 9
+bind = $mainMod SHIFT, 0, movetoworkspace, 10
+
+# Example special workspace (scratchpad)
+bind = $mainMod, S, togglespecialworkspace, magic
+bind = $mainMod SHIFT, S, movetoworkspace, special:magic
+
+# Scroll through existing workspaces with mainMod + scroll
+bind = $mainMod, mouse_down, workspace, e+1
+bind = $mainMod, mouse_up, workspace, e-1
+
+# Move/resize windows with mainMod + LMB/RMB and dragging
+bindm = $mainMod, mouse:272, movewindow
+bindm = $mainMod, mouse:273, resizewindow
+
+
+##############################
+### WINDOWS AND WORKSPACES ###
+##############################
+
+# See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
+# See https://wiki.hyprland.org/Configuring/Workspace-Rules/ for workspace rules
+
+# Example windowrule v1
+# windowrule = float, ^(kitty)$
+
+# Example windowrule v2
+# windowrulev2 = float,class:^(kitty)$,title:^(kitty)$
+
+windowrulev2 = suppressevent maximize, class:.* # You'll probably like this.
+
+misc {
+disable_hyprland_logo = true
+}
+

--- a/config/lxqt-hyprland.conf
+++ b/config/lxqt-hyprland.conf
@@ -62,6 +62,7 @@ windowrule = float,copyq
 #############################
 
 # See https://wiki.hyprland.org/Configuring/Environment-variables/
+# Env vars can also be set in LXQt Session Settings → Advanced
 
 env = XCURSOR_SIZE,24
 env = HYPRCURSOR_SIZE,24

--- a/config/lxqt-sway.config
+++ b/config/lxqt-sway.config
@@ -78,6 +78,7 @@ set $term qterminal
     bindsym alt+F2 exec lxqt-runner
     bindsym $mod+p exec pcmanfm-qt
     bindsym F12 exec qterminal -d
+    bindsym XF86PowerOff exec lxqt-leave
 
     # Ensure applications opened by shortcut are closed gently by LXQt like this for featherpad:
     bindsym $mod F exec pcmanfm-qt '/usr/share/applications/featherpad.desktop'

--- a/config/lxqt-sway.config
+++ b/config/lxqt-sway.config
@@ -1,0 +1,227 @@
+# Default config for LXQt sway
+#
+# Location is ~/.config/lxqt/lxqt-sway-config.sh
+#
+# Read `man 5 sway` for a complete reference.
+
+### Variables
+#
+# Logo key. Use Mod1 for Alt.
+set $mod Mod4
+# Home row direction keys, like vim
+set $left h
+set $down j
+set $up k
+set $right l
+
+# Your preferred terminal emulator
+set $term qterminal
+
+### Output configuration
+#
+# Example configuration:
+#
+#   output HDMI-A-1 resolution 1920x1080 position 1920,0
+#
+# You can get the names of your outputs by running: swaymsg -t get_outputs
+
+### Idle configuration
+#
+# Example configuration:
+#
+# exec swayidle -w \
+#          timeout 300 'swaylock -f -c 000000' \
+#          timeout 600 'swaymsg "output * power off"' resume 'swaymsg "output * power on"' \
+#          before-sleep 'swaylock -f -c 000000'
+#
+# This will lock your screen after 300 seconds of inactivity, then turn off
+# your displays after another 300 seconds, and turn your screens back on when
+# resumed. It will also lock your screen before your computer goes to sleep.
+
+### Input configuration
+#
+# Example configuration:
+#
+#   input "2:14:SynPS/2_Synaptics_TouchPad" {
+#       dwt enabled
+#       tap enabled
+#       natural_scroll enabled
+#       middle_emulation enabled
+#   }
+#
+# You can get the names of your inputs by running: swaymsg -t get_inputs
+# Read `man 5 sway-input` for more information about this section.
+
+### Key bindings
+#
+# Basics:
+#
+    # Start a terminal
+    bindsym $mod+Return exec $term
+
+    # Kill focused window
+    bindsym $mod+Shift+q kill
+
+    # Reload the configuration file
+    bindsym $mod+Shift+r reload
+
+# LXQt Settings
+    exec dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY
+    exec lxqt-session && sway exit
+    for_window [app_id="^lxqt-.*$"] floating enable
+    for_window [app_id="cmst"] floating enable
+    for_window [app_id="kvantummanager"] floating enable
+
+    focus_on_window_activation focus
+
+    bindsym alt+space exec lxqt-runner
+    bindsym alt+F2 exec lxqt-runner
+    bindsym $mod+p exec pcmanfm-qt
+    bindsym F12 exec qterminal -d
+
+    # Ensure applications opened by shortcut are closed gently by LXQt like this for featherpad:
+    bindsym $mod F exec pcmanfm-qt '/usr/share/applications/featherpad.desktop'
+
+    # Full Screenshot
+    bindsym  Shift+Print exec grim /tmp/screen_full_$(date +'%a_%T_.png') && notify-send -a grim -i image -t 2000 "Full screenshot saved"
+    # Select area:
+     bindsym Ctrl+Print exec grim -g "$(slurp)" /tmp/screen_area_$(date +'%a_%T_.png') &&  notify-send -a grim -i image -t 2000 "Selection screenshot saved"
+
+    # Drag floating windows by holding down $mod and left mouse button.
+    # Resize them with right mouse button + $mod.
+    # Despite the name, also works for non-floating windows.
+    # Change normal to inverse to use left mouse button for resizing and right
+    # mouse button for dragging.
+    floating_modifier $mod normal
+
+    # Reload the configuration file
+    bindsym $mod+Shift+c reload
+
+    # Exit sway (logs you out of your Wayland session)
+    bindsym $mod+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -B 'Yes, exit sway' 'swaymsg exit'
+#
+# Moving around:
+#
+    # Move your focus around
+    bindsym $mod+$left focus left
+    bindsym $mod+$down focus down
+    bindsym $mod+$up focus up
+    bindsym $mod+$right focus right
+    # Or use $mod+[up|down|left|right]
+    bindsym $mod+Left focus left
+    bindsym $mod+Down focus down
+    bindsym $mod+Up focus up
+    bindsym $mod+Right focus right
+
+    # Move the focused window with the same, but add Shift
+    bindsym $mod+Shift+$left move left
+    bindsym $mod+Shift+$down move down
+    bindsym $mod+Shift+$up move up
+    bindsym $mod+Shift+$right move right
+    # Ditto, with arrow keys
+    bindsym $mod+Shift+Left move left
+    bindsym $mod+Shift+Down move down
+    bindsym $mod+Shift+Up move up
+    bindsym $mod+Shift+Right move right
+#
+# Workspaces:
+#
+    # Switch to workspace
+    bindsym $mod+1 workspace number 1
+    bindsym $mod+2 workspace number 2
+    bindsym $mod+3 workspace number 3
+    bindsym $mod+4 workspace number 4
+    bindsym $mod+5 workspace number 5
+    bindsym $mod+6 workspace number 6
+    bindsym $mod+7 workspace number 7
+    bindsym $mod+8 workspace number 8
+    bindsym $mod+9 workspace number 9
+    bindsym $mod+0 workspace number 10
+    # Move focused container to workspace
+    bindsym $mod+Shift+1 move container to workspace number 1
+    bindsym $mod+Shift+2 move container to workspace number 2
+    bindsym $mod+Shift+3 move container to workspace number 3
+    bindsym $mod+Shift+4 move container to workspace number 4
+    bindsym $mod+Shift+5 move container to workspace number 5
+    bindsym $mod+Shift+6 move container to workspace number 6
+    bindsym $mod+Shift+7 move container to workspace number 7
+    bindsym $mod+Shift+8 move container to workspace number 8
+    bindsym $mod+Shift+9 move container to workspace number 9
+    bindsym $mod+Shift+0 move container to workspace number 10
+    # Note: workspaces can have any name you want, not just numbers.
+    # We just use 1-10 as the default.
+#
+# Layout stuff:
+#
+    # You can "split" the current object of your focus with
+    # $mod+b or $mod+v, for horizontal and vertical splits
+    # respectively.
+    bindsym $mod+b splith
+    bindsym $mod+v splitv
+
+    # Switch the current container between different layout styles
+    bindsym $mod+s layout stacking
+    bindsym $mod+w layout tabbed
+    bindsym $mod+e layout toggle split
+
+    # Make the current focus fullscreen
+    bindsym $mod+f fullscreen
+
+    # Toggle the current focus between tiling and floating mode
+    bindsym $mod+Shift+space floating toggle
+
+    # Swap focus between the tiling area and the floating area
+    bindsym $mod+space focus mode_toggle
+
+    # Move focus to the parent container
+    bindsym $mod+a focus parent
+#
+# Scratchpad:
+#
+    # Sway has a "scratchpad", which is a bag of holding for windows.
+    # You can send windows there and get them back later.
+
+    # Move the currently focused window to the scratchpad
+    bindsym $mod+Shift+minus move scratchpad
+
+    # Show the next scratchpad window or hide the focused scratchpad window.
+    # If there are multiple scratchpad windows, this command cycles through them.
+    bindsym $mod+minus scratchpad show
+#
+# Resizing containers:
+#
+mode "resize" {
+    # left will shrink the containers width
+    # right will grow the containers width
+    # up will shrink the containers height
+    # down will grow the containers height
+    bindsym $left resize shrink width 10px
+    bindsym $down resize grow height 10px
+    bindsym $up resize shrink height 10px
+    bindsym $right resize grow width 10px
+
+    # Ditto, with arrow keys
+    bindsym Left resize shrink width 10px
+    bindsym Down resize grow height 10px
+    bindsym Up resize shrink height 10px
+    bindsym Right resize grow width 10px
+
+    # Return to default mode
+    bindsym Return mode "default"
+    bindsym Escape mode "default"
+}
+bindsym $mod+r mode "resize"
+
+# Multimedia
+    bindsym XF86AudioRaiseVolume exec pactl set-sink-volume @DEFAULT_SINK@ +5%
+    bindsym XF86AudioLowerVolume exec pactl set-sink-volume @DEFAULT_SINK@ -5%
+    bindsym XF86AudioMute exec pactl set-sink-mute @DEFAULT_SINK@ toggle
+    bindsym XF86AudioMicMute exec pactl set-source-mute @DEFAULT_SOURCE@ toggle
+    bindsym XF86MonBrightnessDown exec brightnessctl set 1-
+    bindsym XF86MonBrightnessUp exec brightnessctl set +1
+    bindsym XF86AudioPlay exec playerctl play-pause
+    bindsym XF86AudioNext exec playerctl next
+    bindsym XF86AudioPrev exec playerctl previous
+
+
+include /etc/sway/config.d/*

--- a/config/lxqt-wayfire.ini
+++ b/config/lxqt-wayfire.ini
@@ -166,6 +166,8 @@ binding_launcher = <alt> KEY_SPACE
 command_launcher = lxqt-runner
 binding_terminaldropdown = KEY_F12
 command_terminaldropdown = qterminal -d
+binding_leave = KEY_POWER
+command_leave = lxqt-leave
 # Ensure applications opened by shortcut are closed gently by LXQt like this for featherpad:
 binding_featherpad = <super> KEY_F
 command_featherpad = pcmanfm-qt '/usr/share/applications/featherpad.desktop'

--- a/config/lxqt-wayfire.ini
+++ b/config/lxqt-wayfire.ini
@@ -1,0 +1,316 @@
+# Default config file for LXQt Wayfire
+#
+# Location is  ~/.config/wayfire-lxqt.ini
+
+# Take the tutorial to get started.
+# https://github.com/WayfireWM/wayfire/wiki/Tutorial
+#
+# Read the Configuration document for a complete reference.
+# https://github.com/WayfireWM/wayfire/wiki/Configuration
+
+# Input configuration ──────────────────────────────────────────────────────────
+
+# Example configuration:
+#(imported from LXQt at start at the bottom)
+[input]
+xkb_layout =
+xkb_variant =
+xkb_options =
+cursor_size = 24
+cursor_theme = default
+#
+# See Input options for a complete reference.
+# https://github.com/WayfireWM/wayfire/wiki/Configuration#input
+
+# Output configuration ─────────────────────────────────────────────────────────
+
+# Example configuration:
+#
+# [output:eDP-1]
+# mode = 1920x1080@60000
+# position = 0,0
+# transform = normal
+# scale = 1.000000
+#
+# You can get the names of your outputs with wlr-randr.
+# https://github.com/emersion/wlr-randr
+#
+# See also kanshi for configuring your outputs automatically.
+# https://wayland.emersion.fr/kanshi/
+#
+# See Output options for a complete reference.
+# https://github.com/WayfireWM/wayfire/wiki/Configuration#output
+
+# Core options ─────────────────────────────────────────────────────────────────
+
+[core]
+
+# List of plugins to be enabled.
+# See the Configuration document for a complete list.
+plugins = \
+  alpha \
+  animate \
+  autostart \
+  command \
+  cube \
+  decoration \
+  expo \
+  fast-switcher \
+  fisheye \
+  foreign-toplevel \
+  grid \
+  gtk-shell \
+  idle \
+  invert \
+  move \
+  oswitch \
+  place \
+  resize \
+  session-lock \
+  shortcuts-inhibit \
+  switcher \
+  vswitch \
+  wayfire-shell \
+  window-rules \
+  wm-actions \
+  wobbly \
+  wrot \
+  zoom
+
+# Note: [blur] is not enabled by default, because it can be resource-intensive.
+# Feel free to add it to the list if you want it.
+# You can find its documentation here:
+# https://github.com/WayfireWM/wayfire/wiki/Configuration#blur
+
+# Close focused window.
+close_top_view = <super> KEY_Q | <alt> KEY_F4
+
+# Workspaces arranged into a grid: 3 × 3.
+vwidth = 3
+vheight = 3
+
+# Prefer client-side decoration or server-side decoration
+preferred_decoration_mode = client
+
+# Mouse bindings ───────────────────────────────────────────────────────────────
+
+# Drag windows by holding down Super and left mouse button.
+[move]
+activate = <super> BTN_LEFT
+
+# Resize them with right mouse button + Super.
+[resize]
+activate = <super> BTN_RIGHT
+
+# Zoom in the desktop by scrolling + Super.
+[zoom]
+modifier = <super>
+
+# Change opacity by scrolling with Super + Alt.
+[alpha]
+modifier = <super> <alt>
+
+# Rotate windows with the mouse.
+[wrot]
+activate = <super> <ctrl> BTN_RIGHT
+
+# Fisheye effect.
+[fisheye]
+toggle = <super> <ctrl> KEY_F
+
+# Startup commands ─────────────────────────────────────────────────────────────
+
+[autostart]
+
+# Automatically start background and panel.
+# Set to false if you want to override the default clients.
+autostart_wf_shell = false
+session = lxqt-session && killall wayfire
+
+# Output configuration
+# https://wayland.emersion.fr/kanshi/
+# outputs = kanshi
+
+# Screen color temperature
+# https://sr.ht/~kennylevinsen/wlsunset/
+gamma = wlsunset
+
+# Idle configuration
+# https://github.com/swaywm/swayidle
+# https://github.com/swaywm/swaylock
+# idle = swayidle before-sleep swaylock
+
+# XDG desktop portal
+# Needed by some GTK applications
+#portal = /usr/libexec/xdg-desktop-portal
+
+# Example configuration:
+#
+# [idle]
+# toggle = <super> KEY_Z
+# screensaver_timeout = 300
+# dpms_timeout = 600
+#
+# Disables the compositor going idle with Super + z.
+# This will lock your screen after 300 seconds of inactivity, then turn off
+# your displays after another 300 seconds.
+
+# Applications ─────────────────────────────────────────────────────────────────
+
+[command]
+
+# Start a terminal
+binding_terminal = <super> KEY_ENTER
+command_terminal = qterminal
+binding_launcher = <alt> KEY_SPACE
+command_launcher = lxqt-runner
+binding_terminaldropdown = KEY_F12
+command_terminaldropdown = qterminal -d
+# Ensure applications opened by shortcut are closed gently by LXQt like this for featherpad:
+binding_featherpad = <super> KEY_F
+command_featherpad = pcmanfm-qt '/usr/share/applications/featherpad.desktop'
+
+# Screen locker
+# https://github.com/swaywm/swaylock
+binding_lock = <super> <shift> KEY_ESC
+command_lock = swaylock
+
+# Logout
+binding_logout = <super> KEY_ESC
+command_logout = lxqt-leave --logout
+
+# Screenshots
+# https://wayland.emersion.fr/grim/
+# https://wayland.emersion.fr/slurp/
+binding_screenshot = KEY_PRINT
+command_screenshot = grim $(date '+%F_%T').webp
+binding_screenshot_interactive = <shift> KEY_PRINT
+command_screenshot_interactive = slurp | grim -g - $(date '+%F_%T').webp
+
+# Volume controls
+# https://alsa-project.org
+repeatable_binding_volume_up = KEY_VOLUMEUP
+command_volume_up = amixer set Master 5%+
+repeatable_binding_volume_down = KEY_VOLUMEDOWN
+command_volume_down = amixer set Master 5%-
+binding_mute = KEY_MUTE
+command_mute = amixer set Master toggle
+
+# Screen brightness
+# https://haikarainen.github.io/light/
+repeatable_binding_light_up = KEY_BRIGHTNESSUP
+repeatable_binding_light_down = KEY_BRIGHTNESSDOWN
+command_light_down = brightnessctl set 5%-
+command_light_up = brightnessctl set 5%+
+
+# Windows ──────────────────────────────────────────────────────────────────────
+
+# Actions related to window management functionalities.
+#
+# Example configuration:
+#
+# [wm-actions]
+# toggle_fullscreen = <super> KEY_F
+# toggle_always_on_top = <super> KEY_X
+# toggle_sticky = <super> <shift> KEY_X
+
+# Position the windows in certain regions of the output.
+[grid]
+#
+# ⇱ ↑ ⇲   │ 7 8 9
+# ← f →   │ 4 5 6
+# ⇱ ↓ ⇲ d │ 1 2 3 0
+# ‾   ‾
+slot_bl = <super> KEY_KP1
+slot_b = <super> KEY_KP2
+slot_br = <super> KEY_KP3
+slot_l = <super> KEY_LEFT | <super> KEY_KP4
+slot_c = <super> KEY_UP | <super> KEY_KP5
+slot_r = <super> KEY_RIGHT | <super> KEY_KP6
+slot_tl = <super> KEY_KP7
+slot_t = <super> KEY_KP8
+slot_tr = <super> KEY_KP9
+# Restore default.
+restore = <super> KEY_DOWN | <super> KEY_KP0
+
+# Change active window with an animation.
+[switcher]
+next_view = <alt> KEY_TAB
+prev_view = <alt> <shift> KEY_TAB
+
+# Simple active window switcher.
+[fast-switcher]
+activate = <alt> KEY_ESC
+
+# Workspaces ───────────────────────────────────────────────────────────────────
+
+# Switch to workspace.
+[vswitch]
+binding_left = <ctrl> <super> KEY_LEFT
+binding_down = <ctrl> <super> KEY_DOWN
+binding_up = <ctrl> <super> KEY_UP
+binding_right = <ctrl> <super> KEY_RIGHT
+# Move the focused window with the same key-bindings, but add Shift.
+with_win_left = <ctrl> <super> <shift> KEY_LEFT
+with_win_down = <ctrl> <super> <shift> KEY_DOWN
+with_win_up = <ctrl> <super> <shift> KEY_UP
+with_win_right = <ctrl> <super> <shift> KEY_RIGHT
+
+# Show the current workspace row as a cube.
+[cube]
+activate = <ctrl> <alt> BTN_LEFT
+# Switch to the next or previous workspace.
+#rotate_left = <super> <ctrl> KEY_H
+#rotate_right = <super> <ctrl> KEY_L
+
+# Show an overview of all workspaces.
+[expo]
+toggle = <super> KEY_E
+# Select a workspace.
+# Workspaces are arranged into a grid of 3 × 3.
+# The numbering is left to right, line by line.
+#
+# ⇱ k ⇲
+# h ⏎ l
+# ⇱ j ⇲
+# ‾   ‾
+# See core.vwidth and core.vheight for configuring the grid.
+select_workspace_1 = KEY_1
+select_workspace_2 = KEY_2
+select_workspace_3 = KEY_3
+select_workspace_4 = KEY_4
+select_workspace_5 = KEY_5
+select_workspace_6 = KEY_6
+select_workspace_7 = KEY_7
+select_workspace_8 = KEY_8
+select_workspace_9 = KEY_9
+
+# Outputs ──────────────────────────────────────────────────────────────────────
+
+# Change focused output.
+[oswitch]
+# Switch to the next output.
+next_output = <super> KEY_O
+# Same with the window.
+next_output_with_win = <super> <shift> KEY_O
+
+# Invert the colors of the whole output.
+[invert]
+toggle = <super> KEY_I
+
+# Send toggle menu event.
+[wayfire-shell]
+toggle_menu = <super>
+
+# Rules ────────────────────────────────────────────────────────────────────────
+
+# Example configuration:
+#
+# [window-rules]
+# maximize_alacritty = on created if app_id is "Alacritty" then maximize
+#
+# You can get the properties of your applications with the following command:
+# $ WAYLAND_DEBUG=1 alacritty 2>&1 | kak
+#
+# See Window rules for a complete reference.
+# https://github.com/WayfireWM/wayfire/wiki/Configuration#window-rules

--- a/startlxqtwayland.in
+++ b/startlxqtwayland.in
@@ -1,0 +1,133 @@
+#!/bin/sh
+
+## LXQt common settings
+contains()
+{
+    local str="$1" substr="$2"
+    [ "$str" = "$substr" -o -z "${str##$substr:*}" -o -z "${str##*:$substr:*}" -o -z "${str%%*:$substr}" ]
+}
+
+if [ -z "$XDG_DATA_HOME" ]; then
+    export XDG_DATA_HOME="$HOME/.local/share"
+fi
+
+if [ -z "$XDG_CONFIG_HOME" ]; then
+    export XDG_CONFIG_HOME="$HOME/.config"
+fi
+
+if [ -z "$XDG_DATA_DIRS" ]; then
+    XDG_DATA_DIRS="$XDG_DATA_HOME:/usr/local/share:/usr/share"
+else
+    if ! contains "$XDG_DATA_DIRS" "/usr/share"; then
+        XDG_DATA_DIRS="$XDG_DATA_DIRS:/usr/share"
+    fi
+fi
+export XDG_DATA_DIRS
+
+if [ -z "$XDG_CONFIG_DIRS" ]; then
+    export XDG_CONFIG_DIRS="/etc:/etc/xdg:/usr/share"
+else
+    if ! contains "$XDG_CONFIG_DIRS" '/etc/xdg'; then
+        XDG_CONFIG_DIRS="$XDG_CONFIG_DIRS:/etc/xdg"
+    fi
+fi
+
+if [ -z "$XDG_CACHE_HOME" ]; then
+    export XDG_CACHE_HOME="$HOME/.cache"
+fi
+
+# Ensure the existence of the 'Desktop' folder
+if [ -e "$XDG_CONFIG_HOME/user-dirs.dirs" ]; then
+    . "$XDG_CONFIG_HOME/user-dirs.dirs"
+else
+    XDG_DESKTOP_DIR="$HOME/Desktop"
+fi
+mkdir -p "$XDG_DESKTOP_DIR"
+
+# Launch DBus if needed
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    if [ -z "$XDG_RUNTIME_DIR" ] || ! [ -S "$XDG_RUNTIME_DIR/bus" ] || ! [ -O "$XDG_RUNTIME_DIR/bus" ]; then
+        eval "$(dbus-launch --sh-syntax --exit-with-session)" || echo "startlxqt: error executing dbus-launch" >&2
+    fi
+fi
+
+# Qt4 platform plugin
+export QT_PLATFORM_PLUGIN="lxqt"
+
+# Qt5 platform plugin
+export QT_QPA_PLATFORMTHEME="lxqt"
+
+# Qt5
+export QT_QPA_PLATFORMTHEME="lxqt"
+export QT_EXCLUDE_GENERIC_BEARER=1
+export QT_AUTO_SCREEN_SCALE_FACTOR=0
+
+# Qt6
+export QT_ACCESSIBILITY=1
+
+# use lxqt-applications.menu for main app menu
+export XDG_MENU_PREFIX="lxqt-"
+
+if [[ ! -d "$XDG_CONFIG_HOME/lxqt/wayland" ]]; then
+    mkdir -p $XDG_CONFIG_HOME/lxqt/wayland/
+fi
+
+if grep -q "compositor" "$XDG_CONFIG_HOME/lxqt/session.conf"; then
+    COMPOSITOR=`cat "$XDG_CONFIG_HOME"/lxqt/session.conf|grep compositor |awk -F'=' '{print $2}'`
+else
+    echo "No compositor set in configuration or configuration not found, trying labwc ..."
+    COMPOSITOR=labwc
+fi
+
+export XDG_CURRENT_DESKTOP="LXQt:$COMPOSITOR:wlroots"
+
+if
+    [[ $COMPOSITOR == "labwc" ]]; then
+    # Copy default labwc configuration if not existing
+    if [[ ! -d "$XDG_CONFIG_HOME/labwc" ]]; then
+        cp -av /usr/share/lxqt/wayland/labwc "$XDG_CONFIG_HOME"/  # use default location here
+    fi
+
+# Import keyboard layout and  cursor settings
+    lxqt2labwcexporter
+
+# enable cursor on VM
+    VIRT=$(systemd-detect-virt)
+    if [ ! "$VIRT" = none ]; then
+        export WLR_NO_HARDWARE_CURSORS=1
+        echo "Running on virtualized hardware"
+    fi
+    exec $COMPOSITOR -C $XDG_CONFIG_HOME/labwc -S lxqt-session
+
+elif
+    [[ $COMPOSITOR = "kwin_wayland" ]]; then
+    # Prevent illegibile text in some KDE apps like systemsettings
+    export QT_QUICK_CONTROLS_STYLE=org.kde.desktop
+    exec kwin_wayland --no-kactivities --exit-with-session lxqt-session --xwayland
+
+elif
+    [[ $COMPOSITOR = "wayfire" ]]; then
+    if [[ ! -f "$XDG_CONFIG_HOME/lxqt/wayland/lxqt-wayfire.ini" ]]; then
+        cp /usr/share/lxqt/wayland/lxqt-wayfire.ini "$XDG_CONFIG_HOME"/lxqt/wayland/
+    fi
+    exec wayfire -c $XDG_CONFIG_HOME/lxqt/wayland/lxqt-wayfire.ini
+
+elif
+    [[ $COMPOSITOR = "sway" ]]; then
+    if [[ ! -f "$XDG_CONFIG_HOME/lxqt/wayland/lxqt-sway.config" ]]; then
+        cp /usr/share/lxqt/wayland/lxqt-sway.config "$XDG_CONFIG_HOME"/lxqt/wayland/
+    fi
+    exec sway -c $XDG_CONFIG_HOME/lxqt/wayland/lxqt-sway.config
+
+elif
+    [[ $COMPOSITOR = "Hyprland" ]]; then
+    if [[ ! -f "$XDG_CONFIG_HOME/lxqt/wayland/lxqt-hyprland.conf" ]]; then
+        cp /usr/share/lxqt/wayland/lxqt-hyprland.conf "$XDG_CONFIG_HOME"/lxqt/wayland/
+    fi
+    exec Hyprland -c $XDG_CONFIG_HOME/lxqt/wayland/lxqt-hyprland.conf
+else
+    echo "No supported compositor found!"
+    echo "The command `lxqt-session && killall $COMPOSITOR` has to be added manually to autostart in $COMPOSITOR."
+    exec $COMPOSITOR
+fi
+

--- a/waylandsession/CMakeLists.txt
+++ b/waylandsession/CMakeLists.txt
@@ -1,0 +1,21 @@
+file(GLOB SESSION_FILES_IN *.desktop.in)
+
+# Translations **********************************
+lxqt_translate_desktop(SESSION_FILES
+    SOURCES
+        ${SESSION_FILES_IN}
+    USE_YAML
+)
+add_custom_target(waylandsession_desktop_files ALL DEPENDS ${SESSION_FILES})
+#************************************************
+
+MACRO(INSTALL_SESSION_FILES directory)
+    install(FILES
+            ${SESSION_FILES}
+            DESTINATION "${directory}"
+            COMPONENT Runtime
+    )
+ENDMACRO(INSTALL_SESSION_FILES)
+
+INSTALL_SESSION_FILES("${CMAKE_INSTALL_DATAROOTDIR}/wayland-sessions")
+

--- a/waylandsession/lxqt-wayland.desktop.in
+++ b/waylandsession/lxqt-wayland.desktop.in
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Exec=startlxqtwayland
+TryExec=startlxqtwayland
+DesktopNames=LXQt
+
+#TRANSLATIONS_DIR=translations

--- a/waylandsession/translations/lxqt-wayland.desktop.yaml
+++ b/waylandsession/translations/lxqt-wayland.desktop.yaml
@@ -1,0 +1,2 @@
+Desktop Entry/Name: "LXQt (Wayland)"
+Desktop Entry/Comment: "Lightweight Qt Desktop - Wayland Session"

--- a/xsession/translations/lxqt.desktop.yaml
+++ b/xsession/translations/lxqt.desktop.yaml
@@ -1,2 +1,2 @@
-Desktop Entry/Name: "LXQt Desktop"
+Desktop Entry/Name: "LXQt Desktop (X11)"
 Desktop Entry/Comment: "Lightweight Qt Desktop"


### PR DESCRIPTION
Atm it needs in `session.conf`  for example `compositor=labwc`.
Check if VM detection can be improved, testing it and use it for all wlroots based compositors.

Will make a PR for the GUI when https://github.com/lxqt/lxqt-session/pull/517 is merged.

![immagine](https://github.com/lxqt/lxqt-session/assets/10681413/3392c47a-cb56-459a-9096-421bf4c1c4ac)

The shipped configurations may need more checks too.

Should we keep "LXQt Desktop" or use "LXQt (X11)"?

It looks like we hadn't updated KF5 version check.