### PR TITLE
Added a checkbox for `X-LXQt-X11-Only` to autostart editor

### DIFF
--- a/lxqt-config-session/autostartedit.cpp
+++ b/lxqt-config-session/autostartedit.cpp
@@ -29,7 +29,7 @@
 
 #include <LXQt/Globals>
 
-AutoStartEdit::AutoStartEdit(const QString& name, const QString& command, bool needTray, QWidget *parent) :
+AutoStartEdit::AutoStartEdit(const QString& name, const QString& command, bool needTray, bool x11Only, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AutoStartEdit)
 {
@@ -38,22 +38,28 @@ AutoStartEdit::AutoStartEdit(const QString& name, const QString& command, bool n
     ui->nameEdit->setText(name);
     ui->commandEdit->setText(command);
     ui->trayCheckBox->setChecked(needTray);
+    ui->x11CheckBox->setChecked(x11Only);
     connect(ui->browseButton, &QPushButton::clicked, this, &AutoStartEdit::browse);
 }
 
-QString AutoStartEdit::name()
+QString AutoStartEdit::name() const
 {
     return ui->nameEdit->text();
 }
 
-QString AutoStartEdit::command()
+QString AutoStartEdit::command() const
 {
     return ui->commandEdit->text();
 }
 
-bool AutoStartEdit::needTray()
+bool AutoStartEdit::needTray() const
 {
     return ui->trayCheckBox->isChecked();
+}
+
+bool AutoStartEdit::x11Only() const
+{
+    return ui->x11CheckBox->isChecked();
 }
 
 void AutoStartEdit::browse()

--- a/lxqt-config-session/autostartedit.h
+++ b/lxqt-config-session/autostartedit.h
@@ -36,11 +36,12 @@ class AutoStartEdit : public QDialog
     Q_OBJECT
 
 public:
-    explicit AutoStartEdit(const QString& name, const QString& command, bool needTray, QWidget* parent = nullptr);
+    explicit AutoStartEdit(const QString& name, const QString& command, bool needTray, bool x11Only, QWidget* parent = nullptr);
     ~AutoStartEdit() override;
-    QString name();
-    QString command();
-    bool needTray();
+    QString name() const;
+    QString command() const;
+    bool needTray() const;
+    bool x11Only() const;
 
 private slots:
     void browse();

--- a/lxqt-config-session/autostartedit.ui
+++ b/lxqt-config-session/autostartedit.ui
@@ -21,23 +21,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QPushButton" name="browseButton">
-     <property name="text">
-      <string>Search...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1" colspan="2">
     <widget class="QLineEdit" name="nameEdit"/>
    </item>
@@ -51,6 +34,13 @@
    <item row="1" column="1">
     <widget class="QLineEdit" name="commandEdit"/>
    </item>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="browseButton">
+     <property name="text">
+      <string>Search...</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="1" colspan="2">
     <widget class="QCheckBox" name="trayCheckBox">
      <property name="text">
@@ -58,15 +48,25 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QCheckBox" name="x11CheckBox">
+     <property name="text">
+      <string>Start only in X11</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>nameEdit</tabstop>
-  <tabstop>commandEdit</tabstop>
-  <tabstop>trayCheckBox</tabstop>
-  <tabstop>buttonBox</tabstop>
-  <tabstop>browseButton</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/lxqt-config-session/autostartpage.cpp
+++ b/lxqt-config-session/autostartpage.cpp
@@ -128,7 +128,7 @@ void AutoStartPage::save()
 
 void AutoStartPage::addButton_clicked()
 {
-    AutoStartEdit edit(QString(), QString(), false);
+    AutoStartEdit edit(QString(), QString(), false, false);
     bool success = false;
     while (!success && edit.exec() == QDialog::Accepted)
     {
@@ -143,6 +143,8 @@ void AutoStartPage::addButton_clicked()
         XdgDesktopFile file(XdgDesktopFile::ApplicationType, trimmedName, trimmedCommand);
         if (edit.needTray())
             file.setValue(QL1S("X-LXQt-Need-Tray"), true);
+        if (edit.x11Only())
+            file.setValue(QL1S("X-LXQt-X11-Only"), true);
         if (mXdgAutoStartModel->setEntry(index, file))
             success = true;
         else
@@ -154,7 +156,10 @@ void AutoStartPage::editButton_clicked()
 {
     QModelIndex index = ui->autoStartView->selectionModel()->currentIndex();
     XdgDesktopFile file = mXdgAutoStartModel->desktopFile(index);
-    AutoStartEdit edit(file.name(), file.value(QL1S("Exec")).toString(), file.contains(QL1S("X-LXQt-Need-Tray")));
+    AutoStartEdit edit(file.name(),
+                       file.value(QL1S("Exec")).toString(),
+                       file.value(QL1S("X-LXQt-Need-Tray"), false).toBool(),
+                       file.value(QL1S("X-LXQt-X11-Only"), false).toBool());
     bool success = false;
     while (!success && edit.exec() == QDialog::Accepted)
     {
@@ -171,6 +176,10 @@ void AutoStartPage::editButton_clicked()
             file.setValue(QL1S("X-LXQt-Need-Tray"), true);
         else
             file.removeEntry(QL1S("X-LXQt-Need-Tray"));
+        if (edit.x11Only())
+            file.setValue(QL1S("X-LXQt-X11-Only"), true);
+        else
+            file.removeEntry(QL1S("X-LXQt-X11-Only"));
 
         if (mXdgAutoStartModel->setEntry(index, file, true))
             success = true;


### PR DESCRIPTION
Also fixed a bug, which checked "Wait for system tray" when editing a desktop entry with `X-LXQt-Need-Tray=false` in it.