### PR TITLE
Added tooltip for scaling under Wayland

### DIFF
--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -107,6 +107,9 @@
    </item>
    <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_4">
+     <property name="toolTip">
+      <string>Under Wayland, adjust scaling via compositor settings or kanshi instead.</string>
+     </property>
      <property name="title">
       <string>Global Screen Scaling</string>
      </property>


### PR DESCRIPTION
… to tell users that it's better to use a Wayland tool for scaling, instead of the global scaling provided by LXQt Session Settings.