### PR TITLE
Updated for Luganda

### DIFF
--- a/lxqt-config-session/translations/lxqt-config-session.ts
+++ b/lxqt-config-session/translations/lxqt-config-session.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ar.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ar.ts
@@ -397,12 +397,12 @@
         <translation>استخدم &quot;loginctl lock-session&quot; على kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>حدد Wayland مؤلّف</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>حدد قفل الشاشة لـ Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_arn.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_arn.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ast.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ast.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_bg.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_bg.ts
@@ -397,12 +397,12 @@
         <translation>Използване на &quot;loginctl lock-session&quot; при kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Избор на композитор на Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Избор на програма за заключване на екрана на Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ca.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ca.ts
@@ -397,12 +397,12 @@
         <translation>Useu loginctl lock-session a kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Seleccioneu un compositor de Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Seleccioneu un blocador de pantalla per a Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_cs.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_cs.ts
@@ -398,12 +398,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_cy.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_cy.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_da.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_da.ts
@@ -397,12 +397,12 @@
         <translation>Brug &quot;loginctl lock-session&quot; på kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Vælg en Wayland-kompositor</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Vælg en skærmlås til Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_de.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_de.ts
@@ -398,12 +398,12 @@
         <translation>Unter kwin_wayland &quot;loginctl lock-session&quot; benutzen</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Wayland Compositor auswählen</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Bildschirmsperre unter Wayland auswählen</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_el.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_el.ts
@@ -397,12 +397,12 @@
         <translation>Χρήση &quot;loginctl lock-session&quot; σε kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Επιλογή ενός συνθέτη Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Επιλογή ενός κλειδώματος οθόνης για το Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_eo.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_eo.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_es.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_es.ts
@@ -397,12 +397,12 @@
         <translation>Usar &quot;loginctl lock-session&quot; en kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Seleccione un Compositor de Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Seleccione un bloqueador de pantalla para Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_es_UY.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_es_UY.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_es_VE.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_es_VE.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_et.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_et.ts
@@ -397,12 +397,12 @@
         <translation>Kui kasutusel on kwin_wayland, siis pruugi käsku „loginctl lock-session“</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Vali Waylandi komposiitor</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Vali Waylandi puhul kasutatav ekraanilukustuse tarvik</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_eu.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_eu.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_fi.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_fi.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_fr.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_fr.ts
@@ -135,7 +135,7 @@
     <message>
         <location filename="../basicsettings.ui" line="126"/>
         <source>Scale factor:</source>
-        <translation>Facteur d&apos;échelle :</translation>
+        <translation>Facteur d&apos;échelle&#xa0;:</translation>
     </message>
     <message>
         <location filename="../basicsettings.ui" line="152"/>
@@ -378,7 +378,7 @@
     <message>
         <location filename="../waylandsettings.ui" line="30"/>
         <source>Wayland compositor:</source>
-        <translation>Compositeur Wayland :</translation>
+        <translation>Compositeur Wayland&#xa0;:</translation>
     </message>
     <message>
         <location filename="../waylandsettings.ui" line="49"/>
@@ -389,7 +389,7 @@
     <message>
         <location filename="../waylandsettings.ui" line="59"/>
         <source>Screenlock command:</source>
-        <translation>Commande de verrouillage de l&apos;écran :</translation>
+        <translation>Commande de verrouillage de l&apos;écran&#xa0;:</translation>
     </message>
     <message>
         <location filename="../waylandsettings.ui" line="71"/>
@@ -397,12 +397,12 @@
         <translation>Utilisez &quot;loginctl lock-session&quot; sur kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Sélectionnez un compositeur Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Sélectionnez un vérouilleur d&apos;écran pour Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_gl.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_gl.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_he.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_he.ts
@@ -397,12 +397,12 @@
         <translation>להשתמש ב־„loginctl” ב־</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>נא לבחור מנהל חלונאי ל־Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>נא לבחור נועל מסך ל־Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_hr.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_hr.ts
@@ -397,12 +397,12 @@
         <translation>Koristi „loginctl lock-session” na kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Odaberi zaključavanje ekrana za Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_hu.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_hu.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ia.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ia.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_id.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_id.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_it.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_it.ts
@@ -397,12 +397,12 @@
         <translation>Usare &quot;loginctl lock-session&quot; in kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Seleziona un compositore Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Seleziona un bloccoschermo per Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ja.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ja.ts
@@ -165,7 +165,7 @@
     <message>
         <location filename="../basicsettings.ui" line="165"/>
         <source>Lock screen before suspending/hibernating</source>
-        <translation>サスペンド/ハイバネートの前に画面をロックする　　　　　　</translation>
+        <translation>サスペンド/ハイバネートの前に画面をロックする&#x3000;&#x3000;&#x3000;&#x3000;&#x3000;&#x3000;</translation>
     </message>
     <message>
         <location filename="../basicsettings.ui" line="172"/>
@@ -397,12 +397,12 @@
         <translation>kwin_waylandでは &quot;loginctl lock-session&quot; を使用します</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Wayland コンポジターの選択</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Wayland の画面ロッカーの選択</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ko.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ko.ts
@@ -397,12 +397,12 @@
         <translation>kwin_wayland에서 &quot;loginctl lock-session&quot;을 사용합니다</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Wayland 컴포지터를 선택합니다</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Wayland용 화면잠금을 선택합니다</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_lg.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_lg.ts
@@ -14,22 +14,27 @@
         <translation>Linnya:</translation>
     </message>
     <message>
-        <location filename="../autostartedit.ui" line="27"/>
+        <location filename="../autostartedit.ui" line="40"/>
         <source>Search...</source>
         <translation>Noonya...</translation>
     </message>
     <message>
-        <location filename="../autostartedit.ui" line="47"/>
+        <location filename="../autostartedit.ui" line="54"/>
+        <source>Start only in X11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../autostartedit.ui" line="30"/>
         <source>Command:</source>
         <translation>Kiragiro:</translation>
     </message>
     <message>
-        <location filename="../autostartedit.ui" line="57"/>
+        <location filename="../autostartedit.ui" line="47"/>
         <source>Wait for system tray</source>
         <translation>Kirinde akakuŋaanyizo kamale okutandika</translation>
     </message>
     <message>
-        <location filename="../autostartedit.cpp" line="61"/>
+        <location filename="../autostartedit.cpp" line="67"/>
         <source>Select Application</source>
         <translation>Londa puloguramu</translation>
     </message>
@@ -80,22 +85,22 @@
         <translation>Puloguramu ezitandikirawo</translation>
     </message>
     <message>
-        <location filename="../autostartpage.cpp" line="138"/>
-        <location filename="../autostartpage.cpp" line="147"/>
-        <location filename="../autostartpage.cpp" line="161"/>
-        <location filename="../autostartpage.cpp" line="174"/>
+        <location filename="../autostartpage.cpp" line="140"/>
+        <location filename="../autostartpage.cpp" line="151"/>
+        <location filename="../autostartpage.cpp" line="170"/>
+        <location filename="../autostartpage.cpp" line="187"/>
         <source>Error</source>
         <translation>Kiremya</translation>
     </message>
     <message>
-        <location filename="../autostartpage.cpp" line="138"/>
-        <location filename="../autostartpage.cpp" line="161"/>
+        <location filename="../autostartpage.cpp" line="140"/>
+        <location filename="../autostartpage.cpp" line="170"/>
         <source>Please provide Name and Command</source>
         <translation>Teekawo ekiragiro n&apos;okunnyonyola</translation>
     </message>
     <message>
-        <location filename="../autostartpage.cpp" line="147"/>
-        <location filename="../autostartpage.cpp" line="174"/>
+        <location filename="../autostartpage.cpp" line="151"/>
+        <location filename="../autostartpage.cpp" line="187"/>
         <source>File &apos;%1&apos; already exists!</source>
         <translation>Waliwo fayiro &apos;%1&apos; esangidwawo!</translation>
     </message>
@@ -134,36 +139,41 @@
     </message>
     <message>
         <location filename="../basicsettings.ui" line="111"/>
+        <source>Under Wayland, adjust scaling via compositor settings or kanshi instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../basicsettings.ui" line="114"/>
         <source>Global Screen Scaling</source>
         <translation>Obunene bw&apos;ebirabikira ku lutimbe</translation>
     </message>
     <message>
-        <location filename="../basicsettings.ui" line="123"/>
+        <location filename="../basicsettings.ui" line="126"/>
         <source>Scale factor:</source>
         <translation>Ekigero ky&apos;obunene:</translation>
     </message>
     <message>
-        <location filename="../basicsettings.ui" line="149"/>
+        <location filename="../basicsettings.ui" line="152"/>
         <source>Leave Session</source>
         <translation>Okukomya olutuula</translation>
     </message>
     <message>
-        <location filename="../basicsettings.ui" line="155"/>
+        <location filename="../basicsettings.ui" line="158"/>
         <source>Ask for confirmation to leave session</source>
         <translation>Okulukomya malanga okukakasa</translation>
     </message>
     <message>
-        <location filename="../basicsettings.ui" line="162"/>
+        <location filename="../basicsettings.ui" line="165"/>
         <source>Lock screen before suspending/hibernating</source>
         <translation>Kompyuta nga en&apos;erindisibwa oba okwebasibwa olutimbe lusaanikirwe</translation>
     </message>
     <message>
-        <location filename="../basicsettings.ui" line="169"/>
+        <location filename="../basicsettings.ui" line="172"/>
         <source>Suspend/hibernate after lock delay:</source>
         <translation>Okulindisa oba okwebasa kutandika nga olutimbe lusaanikiridwa:</translation>
     </message>
     <message>
-        <location filename="../basicsettings.ui" line="182"/>
+        <location filename="../basicsettings.ui" line="185"/>
         <source> ms</source>
         <translation> ms</translation>
     </message>
@@ -212,37 +222,42 @@
 <context>
     <name>SessionConfigWindow</name>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="44"/>
+        <location filename="../sessionconfigwindow.cpp" line="45"/>
         <source>LXQt Session Settings</source>
         <translation>Enteekateeka z&apos;entuula za LXQt</translation>
     </message>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="47"/>
+        <location filename="../sessionconfigwindow.cpp" line="48"/>
         <source>Basic Settings</source>
         <translation>Enteekateeka ez&apos;awamu</translation>
     </message>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="53"/>
+        <location filename="../sessionconfigwindow.cpp" line="54"/>
         <source>User Directories</source>
         <translation>Materekero ez&apos;omu akawunti</translation>
     </message>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="59"/>
+        <location filename="../sessionconfigwindow.cpp" line="60"/>
         <source>Autostart</source>
         <translation>Ebitandikirawo</translation>
     </message>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="65"/>
+        <location filename="../sessionconfigwindow.cpp" line="67"/>
+        <source>Wayland Settings (Experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../sessionconfigwindow.cpp" line="74"/>
         <source>Environment (Advanced)</source>
         <translation>Nviromenti (kyetaagisa bumanyirivu)</translation>
     </message>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="91"/>
+        <location filename="../sessionconfigwindow.cpp" line="100"/>
         <source>Session Restart Required</source>
         <translation>Kyetaagisa kuddamu okutandika olutuula</translation>
     </message>
     <message>
-        <location filename="../sessionconfigwindow.cpp" line="92"/>
+        <location filename="../sessionconfigwindow.cpp" line="101"/>
         <source>Some settings will not take effect until the next log in.</source>
         <translation>Enkyukakyuka ezimu okulabika kyetaagisa okuddamu kutandika olutuula.</translation>
     </message>
@@ -351,6 +366,45 @@
         <location filename="../userlocationspage.cpp" line="80"/>
         <source>Default folder to load or save videos from or to</source>
         <translation>Mu bya bulijjo wano w&apos;oteeka vidiyo zo</translation>
+    </message>
+</context>
+<context>
+    <name>WaylandSettings</name>
+    <message>
+        <location filename="../waylandsettings.ui" line="23"/>
+        <source>Wayland Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../waylandsettings.ui" line="30"/>
+        <source>Wayland compositor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../waylandsettings.ui" line="49"/>
+        <location filename="../waylandsettings.ui" line="81"/>
+        <source>Search...</source>
+        <translation type="unfinished">Noonya...</translation>
+    </message>
+    <message>
+        <location filename="../waylandsettings.ui" line="59"/>
+        <source>Screenlock command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../waylandsettings.ui" line="71"/>
+        <source>Use &quot;loginctl lock-session&quot; on kwin_wayland</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../waylandsettings.cpp" line="98"/>
+        <source>Select a Wayland Compositor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../waylandsettings.cpp" line="103"/>
+        <source>Select a Screenlocker for Wayland</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/lxqt-config-session/translations/lxqt-config-session_lt.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_lt.ts
@@ -397,12 +397,12 @@
         <translation>Naudodami kwin_wayland, naudokite „loginctl lock-session“</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Pasirinkti „Wayland“ tvarkytoją</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Pasirinkti „Wayland“ ekrano užraktą</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_nb_NO.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_nb_NO.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_nl.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_nl.ts
@@ -397,12 +397,12 @@
         <translation>‘loginctl lock-session’ gebruiken kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Kies een Wayland-vensterbeheerder</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Kies een Wayland-schermvergrendeling</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_oc.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_oc.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_pa.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_pa.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_pl.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_pl.ts
@@ -397,12 +397,12 @@
         <translation>Użyj „loginctl lock-session” w kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Wybierz kompozytor Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Wybierz blokadę ekranu dla Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_pt.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_pt.ts
@@ -397,12 +397,12 @@
         <translation>Usar &quot;loginctl lock-session&quot; no kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Selecionar um compositor Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Selecionar um bloqueador de ecrã para Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_pt_BR.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_pt_BR.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ro_RO.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ro_RO.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_ru.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_ru.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_si.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_si.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_sk_SK.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_sk_SK.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_sl.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_sl.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_sr@latin.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_sr@latin.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_sr_RS.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_sr_RS.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_th_TH.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_th_TH.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_tr.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_tr.ts
@@ -397,12 +397,12 @@
         <translation>kwin_wayland üzerinde &quot;loginctl lock-session&quot; kullanın</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Bir Wayland Kompozitörü Seçin</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Wayland için bir Ekran Kilidi seçin</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_uk.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_uk.ts
@@ -397,12 +397,12 @@
         <translation>Використовувати &quot;loginctl lock-session&quot; у kwin_wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>Вибрати композитор Wayland</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>Вибрати блокувальник екрана для Wayland</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_zh_CN.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_zh_CN.ts
@@ -397,12 +397,12 @@
         <translation>在kwin_wayland上用命令&quot;loginctl lock-session&quot;</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation>选择一个Wayland合成器</translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation>选择一个Wayland屏幕锁定程序</translation>
     </message>

--- a/lxqt-config-session/translations/lxqt-config-session_zh_TW.ts
+++ b/lxqt-config-session/translations/lxqt-config-session_zh_TW.ts
@@ -397,12 +397,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="93"/>
+        <location filename="../waylandsettings.cpp" line="98"/>
         <source>Select a Wayland Compositor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../waylandsettings.cpp" line="98"/>
+        <location filename="../waylandsettings.cpp" line="103"/>
         <source>Select a Screenlocker for Wayland</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-leave/translations/lxqt-leave_lg.ts
+++ b/lxqt-leave/translations/lxqt-leave_lg.ts
@@ -14,32 +14,32 @@
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;Kompyuta oyagala ekole etya?&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../leavedialog.cpp" line="55"/>
+        <location filename="../leavedialog.cpp" line="61"/>
         <source>Logout</source>
         <translation>Komya olutuula</translation>
     </message>
     <message>
-        <location filename="../leavedialog.cpp" line="73"/>
+        <location filename="../leavedialog.cpp" line="79"/>
         <source>Reboot</source>
         <translation>Ddamu okukoleeza kompyuta</translation>
     </message>
     <message>
-        <location filename="../leavedialog.cpp" line="60"/>
+        <location filename="../leavedialog.cpp" line="66"/>
         <source>Shutdown</source>
         <translation>Gyako kompyuta</translation>
     </message>
     <message>
-        <location filename="../leavedialog.cpp" line="65"/>
+        <location filename="../leavedialog.cpp" line="71"/>
         <source>Suspend</source>
         <translation>Kompyuta girindise</translation>
     </message>
     <message>
-        <location filename="../leavedialog.cpp" line="70"/>
+        <location filename="../leavedialog.cpp" line="76"/>
         <source>Lock screen</source>
         <translation>Saanikira olutimbe</translation>
     </message>
     <message>
-        <location filename="../leavedialog.cpp" line="78"/>
+        <location filename="../leavedialog.cpp" line="84"/>
         <source>Hibernate</source>
         <translation>Kompyuta gyebase</translation>
     </message>
@@ -52,32 +52,32 @@
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.cpp" line="60"/>
+        <location filename="../main.cpp" line="59"/>
         <source>Logout.</source>
         <translation>Komya olutuula.</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="63"/>
+        <location filename="../main.cpp" line="62"/>
         <source>Lockscreen.</source>
         <translation>Saanikira lutimbe.</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="66"/>
+        <location filename="../main.cpp" line="65"/>
         <source>Suspend.</source>
         <translation>Kompyuta girindise.</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="69"/>
+        <location filename="../main.cpp" line="68"/>
         <source>Hibernate.</source>
         <translation>Kompyuta gyebase.</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="72"/>
+        <location filename="../main.cpp" line="71"/>
         <source>Shutdown.</source>
         <translation>Gyako kompyuta.</translation>
     </message>
     <message>
-        <location filename="../main.cpp" line="75"/>
+        <location filename="../main.cpp" line="74"/>
         <source>Reboot.</source>
         <translation>Ddamu okukoleeza kompyuta.</translation>
     </message>

--- a/lxqt-session/translations/lxqt-session_lg.ts
+++ b/lxqt-session/translations/lxqt-session_lg.ts
@@ -4,12 +4,12 @@
 <context>
     <name>LXQtModuleManager</name>
     <message>
-        <location filename="../src/lxqtmodman.cpp" line="323"/>
+        <location filename="../src/lxqtmodman.cpp" line="330"/>
         <source>Crash Report</source>
         <translation>Alipoota ku kutabuka</translation>
     </message>
     <message>
-        <location filename="../src/lxqtmodman.cpp" line="324"/>
+        <location filename="../src/lxqtmodman.cpp" line="331"/>
         <source>&lt;b&gt;%1&lt;/b&gt; crashed too many times. Its autorestart has been disabled until next login.</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; eyitiriza okutabuka. Okwetandika kusibidwa okutuusa lw&apos;olitandika olutuula olupya.</translation>
     </message>
@@ -33,12 +33,12 @@
         <translation>Ekitekateekamadirisa ekiba kikozesebwa.</translation>
     </message>
     <message>
-        <location filename="../src/sessionapplication.cpp" line="83"/>
+        <location filename="../src/sessionapplication.cpp" line="82"/>
         <source>DBus Environment</source>
         <translation>Ebikwatagana ne DBus</translation>
     </message>
     <message>
-        <location filename="../src/sessionapplication.cpp" line="84"/>
+        <location filename="../src/sessionapplication.cpp" line="83"/>
         <source>The DBus Activation Environment wasn&apos;t updated. Some apps might not work properly</source>
         <translation>Enkyukakyuka mu bikwatagana ne DBus tebikazidwa. Puloguramu ezimu ziyinza butakola nga bwe ziteekwa</translation>
     </message>


### PR DESCRIPTION
Partial fix for https://github.com/lxqt/lxqt/issues/2627#issuecomment-2412564695

It's weird: I changed` <TS version="2.1" language="lg">` to `<TS version="2.1" language="de">` and ran `lxqt2-transupdate, and reversed this change. In one file "Search..." is correctly replaced by "Noonya..." which is Luganda.
