### PR TITLE
Change default cursor_size=18 to 24

### DIFF
--- a/config/session.conf
+++ b/config/session.conf
@@ -6,7 +6,7 @@ GTK_CSD=0
 GTK_OVERLAY_SCROLLING=0
 
 [Mouse]
-cursor_size=18
+cursor_size=24
 cursor_theme=whiteglass
 acc_factor=20
 acc_threshold=10


### PR DESCRIPTION
"18" is not a standard Xcursor nominal size. In addition, it's quite small.

![xcursor1](https://github.com/user-attachments/assets/8334e31f-ed62-4707-bf47-01e49cd74b41)
![xcursor2](https://github.com/user-attachments/assets/d288a296-38f4-4093-9f13-99ccbf165d15)
