### PR TITLE
Added `execDesktopFile` to lxqt-session's D-Bus adaptor

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -288,6 +288,22 @@ void LXQtModuleManager::stopProcess(const QString& name)
         mNameMap[name]->terminate();
 }
 
+void LXQtModuleManager::execDesktopFile(const QString& name)
+{
+    XdgDesktopFile xdg;
+    if (!xdg.load(name))
+    {
+        qCWarning(SESSION) << "Desktop file" << name << "is not valid";
+        return;
+    }
+    if (!xdg.isSuitable())
+    {
+        qCWarning(SESSION) << "Desktop file" << name << "is not applicable";
+        return;
+    }
+    xdg.startDetached();
+}
+
 QStringList LXQtModuleManager::listModules() const
 {
     return QStringList(mNameMap.keys());

--- a/lxqt-session/src/lxqtmodman.h
+++ b/lxqt-session/src/lxqtmodman.h
@@ -85,6 +85,9 @@ public:
     //! \brief Stop a running module
     void stopProcess(const QString& name);
 
+    //! \brief Execute a desktop file, given its file name or path
+    void execDesktopFile(const QString& name);
+
     //! \brief List the running modules, identified by their file names
     QStringList listModules() const;
 

--- a/lxqt-session/src/sessiondbusadaptor.h
+++ b/lxqt-session/src/sessiondbusadaptor.h
@@ -109,6 +109,11 @@ public slots:
         m_manager->stopProcess(name);
     }
 
+    Q_NOREPLY void execDesktopFile(const QString& name)
+    {
+        m_manager->execDesktopFile(name);
+    }
+
 private:
     LXQtModuleManager * m_manager;
     LXQt::Power m_power;


### PR DESCRIPTION
The reason is that we need a way of launching apps under the session tree with shortcuts provided by a Wayland compositor, which is itself outside that tree.

Previously, we recommended launching them with pcmanfm-qt, but apart from the annoying execution prompts, complications were possible. For example, if the desktop module wasn't running, a hidden pcmanfm-qt process would be started, and enabling the desktop module later would result in a desktop outside the session tree.

With this patch, apps can be launched by

```sh
qdbus org.lxqt.session /LXQtSession execDesktopFile DESKTOP_FILE_NAME_OR_PATH
```