### PR TITLE
Prevented a second lxqt-session process

### DIFF
--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -45,7 +45,7 @@ SessionApplication::SessionApplication(int& argc, char** argv) :
     connect(this, &LXQt::Application::unixSignal, modman, [this] { modman->logout(true); });
     new SessionDBusAdaptor(modman);
     // connect to D-Bus and register as an object:
-    QDBusConnection::sessionBus().registerService(QSL("org.lxqt.session"));
+    registered = QDBusConnection::sessionBus().registerService(QSL("org.lxqt.session"));
     QDBusConnection::sessionBus().registerObject(QSL("/LXQtSession"), modman);
 
     // Wait until the event loop starts
@@ -55,6 +55,13 @@ SessionApplication::SessionApplication(int& argc, char** argv) :
 SessionApplication::~SessionApplication()
 {
     delete modman;
+}
+
+int SessionApplication::exec()
+{
+    if (!registered)
+        return 0;
+    return QCoreApplication::exec();
 }
 
 void SessionApplication::setWindowManager(const QString& windowManager)

--- a/lxqt-session/src/sessionapplication.h
+++ b/lxqt-session/src/sessionapplication.h
@@ -32,6 +32,7 @@ class SessionApplication : public LXQt::Application
 public:
     SessionApplication(int& argc, char** argv);
     ~SessionApplication() override;
+    int exec();
     void setWindowManager(const QString & windowManager);
     void setConfigName(const QString & configName);
 
@@ -53,6 +54,7 @@ private:
     LXQtModuleManager* modman;
     LockScreenManager *lockScreenManager;
     QString configName;
+    bool registered;
 };
 
 #endif // SESSIONAPPLICATION_H


### PR DESCRIPTION
Since lxqt-session is started by the compositor on Wayland, this serves as a safeguard. IMO, it's also good for X11.