### PR TITLE
Show autostart applications in the correct category

### DIFF
--- a/lxqt-config-session/autostartmodel.cpp
+++ b/lxqt-config-session/autostartmodel.cpp
@@ -42,7 +42,7 @@ AutoStartItemModel::AutoStartItemModel(QObject* parent) :
     {
         if (!AutostartUtils::isLXQtModule(iter.value().file()))
         {
-            if (showOnlyInLXQt(iter.value().file()))
+            if (AutostartUtils::showOnlyInLXQt(iter.value().file()))
                 mLXQtItems.append(iter.key());
             else
                 mGlobalItems.append(iter.key());
@@ -256,7 +256,7 @@ QModelIndex AutoStartItemModel::parent(const QModelIndex& child) const
     QString name = indexToName(child);
     if (!name.isEmpty())
     {
-        if (showOnlyInLXQt(mItemMap.value(name).file()))
+        if (AutostartUtils::showOnlyInLXQt(mItemMap.value(name).file()))
            return mLXQtIndex;
         return mGlobalIndex;
     }
@@ -278,11 +278,6 @@ int AutoStartItemModel::rowCount(const QModelIndex& parent) const
     if (parent == mLXQtIndex)
         return mLXQtItems.size();
     return 0;
-}
-
-bool AutoStartItemModel::showOnlyInLXQt(const XdgDesktopFile& file)
-{
-    return file.value(QL1S("OnlyShowIn")) == QL1S("LXQt;");
 }
 
 /*

--- a/lxqt-config-session/autostartmodel.h
+++ b/lxqt-config-session/autostartmodel.h
@@ -70,7 +70,6 @@ private:
     QStringList mLXQtItems;
 
     static QString indexToName(const QModelIndex& index);
-    static bool showOnlyInLXQt(const XdgDesktopFile& file);
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(AutoStartItemModel::ActiveButtons)

--- a/lxqt-config-session/autostartutils.cpp
+++ b/lxqt-config-session/autostartutils.cpp
@@ -21,9 +21,13 @@
 
 #include <QString>
 
+using namespace Qt::Literals::StringLiterals;
+
 bool AutostartUtils::showOnlyInLXQt(const XdgDesktopFile &file)
 {
-    return file.value(QLatin1String("OnlyShowIn")) == QLatin1String("LXQt;");
+    const QString values = file.value("OnlyShowIn"_L1).toString();
+    const QStringList desktops = values.split(u';', Qt::SkipEmptyParts);
+    return desktops.contains("LXQt"_L1);
 }
 
 bool AutostartUtils::isLXQtModule(const XdgDesktopFile& file)


### PR DESCRIPTION
Some LXQt only autostart applications were in some conditions being shown in the wrong category (global).
Semicolons are optional for multiple value keys. We were assuming that they were mandatory.

Closes https://github.com/lxqt/lxqt/issues/2708