### PR TITLE
lxqt-leave: prefer QPushButton to QToolButton

### DIFF
--- a/lxqt-leave/leavedialog.ui
+++ b/lxqt-leave/leavedialog.ui
@@ -46,16 +46,13 @@
        </spacer>
       </item>
       <item>
-       <widget class="QToolButton" name="cancelButton">
+       <widget class="QPushButton" name="cancelButton">
         <property name="text">
          <string>Cancel</string>
         </property>
         <property name="icon">
          <iconset theme="dialog-cancel">
           <normaloff>.</normaloff>.</iconset>
-        </property>
-        <property name="toolButtonStyle">
-         <enum>Qt::ToolButtonTextBesideIcon</enum>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
QPushButton is generally styled "nicer" than QToolButton when the goal is dialog buttons. Tested on Fusion, Windows, and Kvantum themes.

Default focus was not an issue because it had default focus prior.

<img width="380" height="100" alt="1" src="https://github.com/user-attachments/assets/1407bcf0-a970-48d0-8921-f7f7a6cd9d73" />
<img width="380" height="100" alt="2" src="https://github.com/user-attachments/assets/35bc84b5-3a64-4316-8320-b81652fd7d15" />
<img width="370" height="100" alt="3" src="https://github.com/user-attachments/assets/d1e4a395-7ccf-4fb9-abcf-c76ac4bc61a7" />
<img width="370" height="100" alt="4" src="https://github.com/user-attachments/assets/32c57d07-125f-4caa-90ac-0a5f29520d71" />


I think the same can be done in a few others places, if this has validity.