### PR TITLE
Don't set scale factors under Wayland

### DIFF
--- a/lxqt-config-session/basicsettings.cpp
+++ b/lxqt-config-session/basicsettings.cpp
@@ -48,6 +48,9 @@ BasicSettings::BasicSettings(LXQt::Settings *settings, QWidget *parent) :
     ui(new Ui::BasicSettings)
 {
     ui->setupUi(this);
+    if (QGuiApplication::platformName() == QL1S("wayland"))
+        ui->scaleBox->setEnabled(false); // scaling is done by the Wayland compositor
+
     connect(ui->findWmButton, &QPushButton::clicked, this, &BasicSettings::findWmButton_clicked);
     connect(ui->startButton,  &QPushButton::clicked, this, &BasicSettings::startButton_clicked);
     connect(ui->stopButton,   &QPushButton::clicked, this, &BasicSettings::stopButton_clicked);

--- a/lxqt-config-session/basicsettings.ui
+++ b/lxqt-config-session/basicsettings.ui
@@ -106,7 +106,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBox_4">
+    <widget class="QGroupBox" name="scaleBox">
      <property name="toolTip">
       <string>Under Wayland, adjust scaling via compositor settings or kanshi instead.</string>
      </property>

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -158,11 +158,16 @@ void SessionApplication::mergeXrdb(const char* content, int len)
 void SessionApplication::loadEnvironmentSettings(LXQt::Settings& settings)
 {
     // first - set some user defined environment variables (like TERM...)
+    bool isWayland(QGuiApplication::platformName() == QL1S("wayland"));
+    static const QLatin1String QtScaleKey("QT_SCALE_FACTOR");
+    static const QLatin1String GdkScaleKey("GDK_SCALE");
     settings.beginGroup(QSL("Environment"));
     QByteArray envVal;
     const QStringList keys = settings.childKeys();
     for(const QString& i : keys)
     {
+        if (isWayland && (i == QtScaleKey || i == GdkScaleKey))
+            continue; // scaling is done by the Wayland compositor
         envVal = settings.value(i).toByteArray();
         lxqt_setenv(i.toLocal8Bit().constData(), envVal);
     }


### PR DESCRIPTION
The values of `QT_SCALE_FACTOR` and `GDK_SCALE` are ignored under Wayland.

Also, the scale box is disabled under Wayland (it isn't hidden because its tooltip is useful).

Closes https://github.com/lxqt/lxqt-session/issues/600