### PR TITLE
Set XDG_CURRENT_DESKTOP for new units started by user service manager

### DIFF
--- a/startlxqt.in
+++ b/startlxqt.in
@@ -64,5 +64,10 @@ export XDG_MENU_PREFIX="lxqt-"
 
 export XDG_CURRENT_DESKTOP="LXQt"
 
+# set environment variables for new units started by user service manager
+if command -v systemctl >/dev/null; then
+    systemctl --user import-environment XDG_CURRENT_DESKTOP
+fi
+
 # Start the LXQt session
 exec lxqt-session


### PR DESCRIPTION
This fixes the problem that XDG Desktop Portal does not use the LXQt backend under LXQt session.