### PR TITLE
wmselectdialog: Update translation for Session Settings change; misc. cleanup

### DIFF
--- a/lxqt-config-session/autostartedit.ui
+++ b/lxqt-config-session/autostartedit.ui
@@ -74,32 +74,12 @@
    <signal>accepted()</signal>
    <receiver>AutoStartEdit</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>254</x>
-     <y>96</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>102</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
    <receiver>AutoStartEdit</receiver>
    <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>322</x>
-     <y>96</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>102</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>

--- a/lxqt-session/src/numlock.cpp
+++ b/lxqt-session/src/numlock.cpp
@@ -38,7 +38,7 @@
 
 /* the XKB stuff is based on code created by Oswald Buddenhagen <ossi@kde.org> */
 
-static unsigned int xkb_mask_modifier(Display* /*dpy*/, XkbDescPtr xkb, const char *name )
+static unsigned int xkb_mask_modifier(Display* /*dpy*/, XkbDescPtr xkb, const char *name)
 {
     int i = 0;
     if( !xkb || !xkb->names )
@@ -71,7 +71,7 @@ static int xkb_set_on(Display* dpy)
     mask = xkb_numlock_mask(dpy);
     if( mask == 0 )
         return 0;
-    XkbLockModifiers ( dpy, XkbUseCoreKbd, mask, mask);
+    XkbLockModifiers (dpy, XkbUseCoreKbd, mask, mask);
     return 1;
 }
 

--- a/lxqt-session/src/windowmanager.cpp
+++ b/lxqt-session/src/windowmanager.cpp
@@ -34,7 +34,6 @@
 #include <LXQt/Settings>
 #include <QDebug>
 
-
 bool findProgram(const QString &program)
 {
     return !QStandardPaths::findExecutable(program).isEmpty();

--- a/lxqt-session/src/wmselectdialog.cpp
+++ b/lxqt-session/src/wmselectdialog.cpp
@@ -48,7 +48,6 @@ WmSelectDialog::WmSelectDialog(const WindowManagerList &availableWindowManagers,
     QDialog(parent),
     ui(new Ui::WmSelectDialog)
 {
-    qApp->setStyle(QSL("plastique"));
     ui->setupUi(this);
     setModal(true);
     connect(ui->wmList, &QTreeWidget::doubleClicked, this, &WmSelectDialog::accept);

--- a/lxqt-session/src/wmselectdialog.ui
+++ b/lxqt-session/src/wmselectdialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to LXQt&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please select your default Window Manager.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Welcome to LXQt&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please select your default Window Manager:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -68,7 +68,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>You will be able to change this at any time through Preferences -&gt; Session Settings -&gt; Basic Settings.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You will be able to change this at any time through &lt;span style=&quot;font-weight:600;&quot;&gt;LXQt Settings → Session Settings → X11 Settings&lt;/span&gt;.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -94,32 +94,12 @@
    <signal>accepted()</signal>
    <receiver>WmSelectDialog</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
    <receiver>WmSelectDialog</receiver>
    <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>


### PR DESCRIPTION
Two strings were changed:
1. Replace `.` with `:` (translations may be able to be preserved)
2. Update to match updated Session Settings GUI

Small code cleanup